### PR TITLE
r1: Fix invalid InteriorIntersects verification.

### DIFF
--- a/r1/interval.go
+++ b/r1/interval.go
@@ -84,7 +84,7 @@ func (i Interval) Intersects(oi Interval) bool {
 
 // InteriorIntersects returns true iff the interior of the interval contains any points in common with oi, including the latter's boundary.
 func (i Interval) InteriorIntersects(oi Interval) bool {
-	return oi.Lo < i.Hi && i.Lo < oi.Hi && i.Lo < i.Hi && oi.Lo <= i.Hi
+	return oi.Lo < i.Hi && i.Lo < oi.Hi && i.Lo < i.Hi && oi.Lo <= oi.Hi
 }
 
 // Intersection returns the interval containing all points common to i and j.

--- a/r1/interval_test.go
+++ b/r1/interval_test.go
@@ -190,6 +190,14 @@ func TestIntervalOperations(t *testing.T) {
 			intersects:         true,
 			interiorIntersects: false,
 		},
+		{
+			have:               Interval{1, 2.1},
+			other:              Interval{2, 1.9},
+			contains:           true,
+			interiorContains:   true,
+			intersects:         false,
+			interiorIntersects: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
InteriorIntersects was using interval i instead of the other interval io to check if io was empty.

### Reference code in C++
```
  // Return true if the interior of this interval intersects
  // any point of the given interval (including its boundary).
  bool InteriorIntersects(R1Interval const& y) const {
    return y.lo() < hi() && lo() < y.hi() && lo() < hi() && y.lo() <= y.hi();
  }
```