### PR TITLE
WIP: Implement ConvexHullQuery

### DIFF
--- a/s2/convex_hull_query.go
+++ b/s2/convex_hull_query.go
@@ -1,0 +1,218 @@
+// Copyright 2018 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package s2
+
+import (
+	"sort"
+
+	"github.com/golang/geo/r3"
+)
+
+// ConvexHullQuery builds the convex hull of any collection of points,
+// polylines, loops, and polygons.  It returns a single convex loop.
+//
+// The convex hull is defined as the smallest convex region on the sphere that
+// contains all of your input geometry.  Recall that a region is "convex" if
+// for every pair of points inside the region, the straight edge between them
+// is also inside the region.  In our case, a "straight" edge is a geodesic,
+// i.e. the shortest path on the sphere between two points.
+//
+// Containment of input geometry is defined as follows:
+//
+//  - Each input loop and polygon is contained by the convex hull exactly
+//    (i.e., according to S2Polygon::Contains(S2Polygon)).
+//
+//  - Each input point is either contained by the convex hull or is a vertex
+//    of the convex hull. (Recall that S2Loops do not necessarily contain their
+//    vertices.)
+//
+//  - For each input polyline, the convex hull contains all of its vertices
+//    according to the rule for points above.  (The definition of convexity
+//    then ensures that the convex hull also contains the polyline edges.)
+//
+// To use this class, call the Add*() methods to add your input geometry, and
+// then call GetConvexHull().  Note that GetConvexHull() does *not* reset the
+// state; you can continue adding geometry if desired and compute the convex
+// hull again.  If you want to start from scratch, simply declare a new
+// S2ConvexHullQuery object (they are cheap to create).
+type ConvexHullQuery struct {
+	points []Point
+	bound  Rect
+}
+
+// AddPoint adds one or more points to the input geometry.
+func (q *ConvexHullQuery) AddPoint(point Point) {
+	q.points = append(q.points, point)
+}
+
+// AddPolyline add a polyline to the input geometry.
+func (q *ConvexHullQuery) AddPolyline(polyline Polyline) {
+	q.bound = q.bound.Union(polyline.RectBound())
+
+	q.points = append(q.points, polyline...)
+}
+
+// AddLoop adds one or more loops to the input geometry.
+func (q *ConvexHullQuery) AddLoop(loop *Loop) {
+	q.bound = q.bound.Union(loop.bound)
+	if loop.isEmptyOrFull() {
+		return
+	}
+
+	q.points = append(q.points, loop.vertices...)
+}
+
+// AddPolygon adds one or more polygons to the input geometry.
+func (q *ConvexHullQuery) AddPolygon(polygon *Polygon) {
+	for i := range polygon.loops {
+		q.AddLoop(polygon.loops[i])
+	}
+}
+
+// CapBound computes a bounding cap for the input geometry provided.
+//
+// Note that this method does not clear the geometry; you can continue
+// adding to it and call this method again if desired.
+func (q *ConvexHullQuery) CapBound() Cap {
+	return q.bound.CapBound()
+}
+
+// ConvexHull computes the convex hull of the input geometry provided.
+//
+// If there is no geometry, this method returns an empty loop containing no
+// points (see S2Loop::is_empty()).
+//
+// If the geometry spans more than half of the sphere, this method returns a
+// full loop containing the entire sphere (see S2Loop::is_full()).
+//
+// If the geometry contains 1 or 2 points, or a single edge, this method
+// returns a very small loop consisting of three vertices (which are a
+// superset of the input vertices).
+//
+// Note that this method does not clear the geometry; you can continue
+// adding to it and call this method again if desired.
+func (q *ConvexHullQuery) ConvexHull() *Loop {
+	cap := q.CapBound()
+	if cap.Height() >= 1 {
+		// The bounding cap is not convex.  The current bounding cap
+		// implementation is not optimal, but nevertheless it is likely that the
+		// input geometry itself is not contained by any convex polygon.  In any
+		// case, we need a convex bounding cap to proceed with the algorithm below
+		// (in order to construct a point "origin" that is definitely outside the
+		// convex hull).
+		return FullLoop()
+	}
+
+	// This code implements Andrew's monotone chain algorithm, which is a simple
+	// variant of the Graham scan.  Rather than sorting by x-coordinate, instead
+	// we sort the points in CCW order around an origin O such that all points
+	// are guaranteed to be on one side of some geodesic through O.  This
+	// ensures that as we scan through the points, each new point can only
+	// belong at the end of the chain (i.e., the chain is monotone in terms of
+	// the angle around O from the starting point).
+	origin := cap.Center().Ortho()
+	sortPointsCcwAround(q.points, origin)
+
+	// Remove duplicates.  We need to do this before checking whether there are
+	// fewer than 3 points.
+	q.points = uniquePoints(q.points)
+
+	switch len(q.points) {
+	case 0:
+		return EmptyLoop()
+	case 1:
+		return singlePointLoop(q.points[0])
+	case 2:
+		return singleEdgeLoop(q.points[0], q.points[1])
+	}
+
+	var lower, upper []Point
+	q.getMonotoneChain(&lower)
+	reversePoints(q.points)
+	q.getMonotoneChain(&upper)
+
+	lower = lower[:len(lower)-1]
+	upper = upper[:len(upper)-1]
+	lower = append(lower, upper...)
+
+	return LoopFromPoints(lower)
+}
+
+// pointsCcwAroundSorter implements the Sort interface for slices of Point
+// with a comparator for sorting points in CCW around a central point "center".
+type pointsCcwAroundSorter struct {
+	center Point
+	points []Point
+}
+
+func (s pointsCcwAroundSorter) Len() int           { return len(s.points) }
+func (s pointsCcwAroundSorter) Swap(i, j int)      { s.points[i], s.points[j] = s.points[j], s.points[i] }
+func (s pointsCcwAroundSorter) Less(i, j int) bool { return Sign(s.center, s.points[i], s.points[j]) }
+
+func sortPointsCcwAround(points []Point, origin r3.Vector) {
+	sorter := pointsCcwAroundSorter{
+		center: Point{origin},
+		points: points,
+	}
+	sort.Sort(sorter)
+}
+
+func uniquePoints(points []Point) []Point {
+	seen := make(map[Point]struct{}, len(points))
+	i := 0
+	for _, v := range points {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		points[i] = v
+		i++
+	}
+	return points[:i]
+}
+
+func reversePoints(points []Point) {
+	for left, right := 0, len(points)-1; left < right; left, right = left+1, right-1 {
+		points[left], points[right] = points[right], points[left]
+	}
+}
+
+const singlePointLoopOffset = 1e-15
+
+func singlePointLoop(p Point) *Loop {
+	d0 := p.Ortho()
+	d1 := p.Cross(d0)
+	vertices := make([]Point, 3)
+	vertices[0] = p
+	vertices[1] = Point{p.Add(d0.Mul(singlePointLoopOffset)).Normalize()}
+	vertices[2] = Point{p.Add(d1.Mul(singlePointLoopOffset)).Normalize()}
+	return LoopFromPoints(vertices)
+}
+
+func singleEdgeLoop(a, b Point) *Loop {
+	vertices := make([]Point, 3)
+	vertices[0] = a
+	vertices[1] = b
+	vertices[2] = Point{a.Add(b.Vector).Normalize()}
+	return LoopFromPoints(vertices)
+}
+
+func (q *ConvexHullQuery) getMonotoneChain(output *[]Point) {
+	for i := range q.points {
+		for outLen := len(*output); outLen >= 2 && Sign((*output)[outLen-2], (*output)[outLen-1], q.points[i]); outLen = len(*output) {
+			*output = (*output)[:outLen-1]
+		}
+		*output = append(*output, q.points[i])
+	}
+}

--- a/s2/convex_hull_query_test.go
+++ b/s2/convex_hull_query_test.go
@@ -123,7 +123,7 @@ func testConvexHullQueryNorthPoleLoop(radius s1.Angle, numVertices int, t *testi
 	loop := RegularLoop(PointFromCoords(0, 0, 1), radius, numVertices)
 	query.AddLoop(loop)
 	res := query.ConvexHull()
-	if radius.Radians() > 2*math.Pi {
+	if radius.Radians() > math.Pi/2 {
 		expectTrue(res.IsFull(), t)
 	} else {
 		expectTrue(res.BoundaryEqual(loop), t)

--- a/s2/convex_hull_query_test.go
+++ b/s2/convex_hull_query_test.go
@@ -1,0 +1,201 @@
+// Copyright 2018 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package s2
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/golang/geo/s1"
+)
+
+func TestConvexHullQueryNoPoints(t *testing.T) {
+	q := new(ConvexHullQuery)
+	expectTrue(q.ConvexHull().IsEmpty(), t)
+}
+
+func loopHasVertex(loop *Loop, point Point) bool {
+	_, ok := loop.findVertex(point)
+	return ok
+}
+
+func TestConvexHullQueryOnePoint(t *testing.T) {
+	query := new(ConvexHullQuery)
+	p := PointFromCoords(0, 0, 1)
+	query.AddPoint(p)
+
+	res := query.ConvexHull()
+	expectInt(3, res.NumVertices(), t)
+	expectTrue(res.IsNormalized(), t)
+	expectTrue(loopHasVertex(res, p), t)
+
+	// Add some duplicate points and check that the result is the same.
+	query.AddPoint(p)
+	query.AddPoint(p)
+	expectTrue(res.BoundaryEqual(query.ConvexHull()), t)
+}
+
+func TestConvexHullQueryTwoPoints(t *testing.T) {
+	query := new(ConvexHullQuery)
+	p := PointFromCoords(0, 0, 1)
+	q := PointFromCoords(0, 1, 0)
+	query.AddPoint(p)
+	query.AddPoint(q)
+
+	res := query.ConvexHull()
+	expectInt(3, res.NumVertices(), t)
+	expectTrue(res.IsNormalized(), t)
+	expectTrue(loopHasVertex(res, p), t)
+	expectTrue(loopHasVertex(res, q), t)
+
+	query.AddPoint(p)
+	query.AddPoint(p)
+	query.AddPoint(q)
+	expectTrue(res.BoundaryEqual(query.ConvexHull()), t)
+}
+
+func TestConvexHullQueryEmptyLoop(t *testing.T) {
+	query := new(ConvexHullQuery)
+	query.AddLoop(EmptyLoop())
+	res := query.ConvexHull()
+	expectTrue(res.IsEmpty(), t)
+}
+
+func TestConvexHullQueryFullLoop(t *testing.T) {
+	query := new(ConvexHullQuery)
+	query.AddLoop(FullLoop())
+	res := query.ConvexHull()
+	expectTrue(res.IsFull(), t)
+}
+
+func TestConvexHullQueryEmptyPolygon(t *testing.T) {
+	query := new(ConvexHullQuery)
+	empty := PolygonFromLoops(make([]*Loop, 0))
+	query.AddPolygon(empty)
+	res := query.ConvexHull()
+	expectTrue(res.IsEmpty(), t)
+}
+
+func TestConvexHullQueryNonConvexPoints(t *testing.T) {
+	// Generate a point set such that the only convex region containing them is
+	// the entire sphere.  In other words, you can generate any point on the
+	// sphere by repeatedly linearly interpolating between the points.  (The
+	// four points of a tetrahedron would also work, but this is easier.)
+	query := new(ConvexHullQuery)
+	for i := 0; i < 6; i++ {
+		query.AddPoint(CellIDFromFace(i).Point())
+	}
+	res := query.ConvexHull()
+	expectTrue(res.IsFull(), t)
+}
+
+func TestConvexHullQuerySimplePolyline(t *testing.T) {
+	// A polyline is handling identically to a point set, so there is no need
+	// for special testing other than code coverage.
+	query := new(ConvexHullQuery)
+	polyline := makePolyline("0:1, 0:9, 1:6, 2:6, 3:10, 4:10, 5:5, 4:0, 3:0, 2:5, 1:5")
+	query.AddPolyline(*polyline)
+	res := query.ConvexHull()
+	expected := makeLoop("0:1, 0:9, 3:10, 4:10, 5:5, 4:0, 3:0")
+
+	expectTrue(res.BoundaryEqual(expected), t)
+}
+
+func testConvexHullQueryNorthPoleLoop(radius s1.Angle, numVertices int, t *testing.T) {
+	// A polyline is handling identically to a point set, so there is no need
+	// for special testing other than code coverage.
+	query := new(ConvexHullQuery)
+	loop := RegularLoop(PointFromCoords(0, 0, 1), radius, numVertices)
+	query.AddLoop(loop)
+	res := query.ConvexHull()
+	if radius.Radians() > 2*math.Pi {
+		fmt.Println("a")
+		expectTrue(res.IsFull(), t)
+	} else {
+		fmt.Println("b")
+		expectTrue(res.BoundaryEqual(loop), t)
+	}
+}
+
+func TestConvexHullQueryLoopsAroundNorthPole(t *testing.T) {
+	// Test loops of various sizes around the north pole.
+	testConvexHullQueryNorthPoleLoop(s1.Degree, 3, t)
+	testConvexHullQueryNorthPoleLoop(89*s1.Degree, 3, t)
+
+	// The following two loops should yield the full loop.
+	testConvexHullQueryNorthPoleLoop(91*s1.Degree, 3, t)
+	testConvexHullQueryNorthPoleLoop(179*s1.Degree, 3, t)
+
+	testConvexHullQueryNorthPoleLoop(10*s1.Degree, 100, t)
+	testConvexHullQueryNorthPoleLoop(89*s1.Degree, 1000, t)
+}
+
+func TestConvexHullPointsInsideHull(t *testing.T) {
+	// Repeatedly build the convex hull of a set of points, then add more points
+	// inside that loop and build the convex hull again.  The result should
+	// always be the same.
+	for i := 0; i < 1000; i++ {
+		// Choose points from within a cap of random size, up to but not including
+		// an entire hemisphere.
+		cap := randomCap(1e-15, 1.999*math.Pi)
+		query := new(ConvexHullQuery)
+
+		numPts := randomUniformInt(100) + 3
+		for j := 0; j < numPts; j++ {
+			query.AddPoint(samplePointFromCap(cap))
+		}
+
+		hull := query.ConvexHull()
+
+		// When the convex hull is nearly a hemisphere, the algorithm sometimes
+		// returns a full cap instead.  This is because it first computes a
+		// bounding rectangle for all the input points/edges and then converts it
+		// to a bounding cap, which sometimes yields a non-convex cap (radius
+		// larger than 90 degrees).  This should not be a problem in practice
+		// (since most convex hulls are not hemispheres), but in order make this
+		// test pass reliably it means that we need to reject convex hulls whose
+		// bounding cap (when computed from a bounding rectangle) is not convex.
+		//
+		// TODO(ericv): This test can still fail (about 1 iteration in 500,000)
+		// because the S2LatLngRect::GetCapBound implementation does not guarantee
+		// that A.Contains(B) implies A.GetCapBound().Contains(B.GetCapBound()).
+		if hull.CapBound().Height() >= 1 {
+			continue
+		}
+
+		// Otherwise, add more points inside the convex hull.
+		for j := 0; j < 1000; j++ {
+			p := samplePointFromCap(cap)
+			if hull.ContainsPoint(p) {
+				query.AddPoint(p)
+			}
+		}
+
+		hull2 := query.ConvexHull()
+		expectTrue(hull2.BoundaryEqual(hull), t)
+	}
+}
+
+func expectTrue(b bool, t *testing.T) {
+	if !b {
+		t.Fatalf("Expected true, got false")
+	}
+}
+
+func expectInt(expected, actual int, t *testing.T) {
+	if expected != actual {
+		t.Fatalf("Expected %d, got %d", expected, actual)
+	}
+}

--- a/s2/convex_hull_query_test.go
+++ b/s2/convex_hull_query_test.go
@@ -11,10 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package s2
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
@@ -22,7 +22,7 @@ import (
 )
 
 func TestConvexHullQueryNoPoints(t *testing.T) {
-	q := new(ConvexHullQuery)
+	q := NewConvexHullQuery()
 	expectTrue(q.ConvexHull().IsEmpty(), t)
 }
 
@@ -32,7 +32,7 @@ func loopHasVertex(loop *Loop, point Point) bool {
 }
 
 func TestConvexHullQueryOnePoint(t *testing.T) {
-	query := new(ConvexHullQuery)
+	query := NewConvexHullQuery()
 	p := PointFromCoords(0, 0, 1)
 	query.AddPoint(p)
 
@@ -48,7 +48,7 @@ func TestConvexHullQueryOnePoint(t *testing.T) {
 }
 
 func TestConvexHullQueryTwoPoints(t *testing.T) {
-	query := new(ConvexHullQuery)
+	query := NewConvexHullQuery()
 	p := PointFromCoords(0, 0, 1)
 	q := PointFromCoords(0, 1, 0)
 	query.AddPoint(p)
@@ -67,21 +67,21 @@ func TestConvexHullQueryTwoPoints(t *testing.T) {
 }
 
 func TestConvexHullQueryEmptyLoop(t *testing.T) {
-	query := new(ConvexHullQuery)
+	query := NewConvexHullQuery()
 	query.AddLoop(EmptyLoop())
 	res := query.ConvexHull()
 	expectTrue(res.IsEmpty(), t)
 }
 
 func TestConvexHullQueryFullLoop(t *testing.T) {
-	query := new(ConvexHullQuery)
+	query := NewConvexHullQuery()
 	query.AddLoop(FullLoop())
 	res := query.ConvexHull()
 	expectTrue(res.IsFull(), t)
 }
 
 func TestConvexHullQueryEmptyPolygon(t *testing.T) {
-	query := new(ConvexHullQuery)
+	query := NewConvexHullQuery()
 	empty := PolygonFromLoops(make([]*Loop, 0))
 	query.AddPolygon(empty)
 	res := query.ConvexHull()
@@ -93,7 +93,7 @@ func TestConvexHullQueryNonConvexPoints(t *testing.T) {
 	// the entire sphere.  In other words, you can generate any point on the
 	// sphere by repeatedly linearly interpolating between the points.  (The
 	// four points of a tetrahedron would also work, but this is easier.)
-	query := new(ConvexHullQuery)
+	query := NewConvexHullQuery()
 	for i := 0; i < 6; i++ {
 		query.AddPoint(CellIDFromFace(i).Point())
 	}
@@ -104,9 +104,12 @@ func TestConvexHullQueryNonConvexPoints(t *testing.T) {
 func TestConvexHullQuerySimplePolyline(t *testing.T) {
 	// A polyline is handling identically to a point set, so there is no need
 	// for special testing other than code coverage.
-	query := new(ConvexHullQuery)
+	query := NewConvexHullQuery()
 	polyline := makePolyline("0:1, 0:9, 1:6, 2:6, 3:10, 4:10, 5:5, 4:0, 3:0, 2:5, 1:5")
-	query.AddPolyline(*polyline)
+	for _, p := range *polyline {
+		query.AddPoint(p)
+	}
+	//query.AddPolyline(*polyline)
 	res := query.ConvexHull()
 	expected := makeLoop("0:1, 0:9, 3:10, 4:10, 5:5, 4:0, 3:0")
 
@@ -116,15 +119,13 @@ func TestConvexHullQuerySimplePolyline(t *testing.T) {
 func testConvexHullQueryNorthPoleLoop(radius s1.Angle, numVertices int, t *testing.T) {
 	// A polyline is handling identically to a point set, so there is no need
 	// for special testing other than code coverage.
-	query := new(ConvexHullQuery)
+	query := NewConvexHullQuery()
 	loop := RegularLoop(PointFromCoords(0, 0, 1), radius, numVertices)
 	query.AddLoop(loop)
 	res := query.ConvexHull()
 	if radius.Radians() > 2*math.Pi {
-		fmt.Println("a")
 		expectTrue(res.IsFull(), t)
 	} else {
-		fmt.Println("b")
 		expectTrue(res.BoundaryEqual(loop), t)
 	}
 }
@@ -150,7 +151,7 @@ func TestConvexHullPointsInsideHull(t *testing.T) {
 		// Choose points from within a cap of random size, up to but not including
 		// an entire hemisphere.
 		cap := randomCap(1e-15, 1.999*math.Pi)
-		query := new(ConvexHullQuery)
+		query := NewConvexHullQuery()
 
 		numPts := randomUniformInt(100) + 3
 		for j := 0; j < numPts; j++ {

--- a/s2/loop.go
+++ b/s2/loop.go
@@ -379,6 +379,16 @@ func (l *Loop) BoundaryEqual(o *Loop) bool {
 			// There is at most one starting offset since loop vertices are unique.
 			for i := 0; i < len(l.vertices); i++ {
 				if l.Vertex(i+offset) != o.Vertex(i) {
+					if i == 1 {
+						// Try the other direction
+						for j := 0; j < len(l.vertices); j++ {
+							// Add len(l.vertices) for wrap-around
+							if l.Vertex(len(l.vertices)+offset-j) != o.Vertex(j) {
+								return false
+							}
+						}
+						return true
+					}
 					return false
 				}
 			}


### PR DESCRIPTION
This is a port of the C++ ConvexHullQuery code.

Also adds detection for reversed versions of a loop in `Loop.BoundaryEqual()` (noticed when porting `TestConvexHullQuerySimplePolyline`)

There are some bugs and the tests aren't working but I figure'd I'd do the PR anyway to get some feedback right away.