### PR TITLE
Fix problems identified by golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+linters:
+  enable-all: true
+  disable:
+    - deadcode
+    - dupl
+    - gochecknoglobals
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - govet
+    - lll
+    - maligned
+    - nakedret
+    - unparam
+    - unused
+    - varcheck

--- a/r3/precisevector.go
+++ b/r3/precisevector.go
@@ -64,7 +64,7 @@ func precMul(a, b *big.Float) *big.Float {
 // PreciseVector represents a point in ℝ³ using high-precision values.
 // Note that this is NOT a complete implementation because there are some
 // operations that Vector supports that are not feasible with arbitrary precision
-// math. (e.g., methods that need divison like Normalize, or methods needing a
+// math. (e.g., methods that need division like Normalize, or methods needing a
 // square root operation such as Norm)
 type PreciseVector struct {
 	X, Y, Z *big.Float

--- a/s2/cellid.go
+++ b/s2/cellid.go
@@ -354,7 +354,7 @@ func cellIDFromString(s string) CellID {
 	id := CellIDFromFace(face)
 	for i := 2; i < len(s); i++ {
 		childPos := s[i] - '0'
-		if childPos < 0 || childPos > 3 {
+		if childPos > 3 {
 			return CellID(0)
 		}
 		id = id.Children()[childPos]

--- a/s2/cellid.go
+++ b/s2/cellid.go
@@ -576,8 +576,8 @@ func cellIDFromFaceIJ(f, i, j int) CellID {
 	// Hilbert curve orientation respectively.
 	for k := 7; k >= 0; k-- {
 		mask := (1 << lookupBits) - 1
-		bits += int((i>>uint(k*lookupBits))&mask) << (lookupBits + 2)
-		bits += int((j>>uint(k*lookupBits))&mask) << 2
+		bits += (i >> uint(k*lookupBits)) & mask << (lookupBits + 2)
+		bits += (j >> uint(k*lookupBits)) & mask << 2
 		bits = lookupPos[bits]
 		n |= uint64(bits>>2) << (uint(k) * 2 * lookupBits)
 		bits &= (swapMask | invertMask)

--- a/s2/cellunion.go
+++ b/s2/cellunion.go
@@ -379,7 +379,7 @@ func areSiblings(a, b, c, d CellID) bool {
 	// mask that blocks out the two bits that encode the child position of
 	// "id" with respect to its parent, then check that the other three
 	// children all agree with "mask".
-	mask := uint64(d.lsb() << 1)
+	mask := d.lsb() << 1
 	mask = ^(mask + (mask << 1))
 	idMasked := (uint64(d) & mask)
 	return ((uint64(a)&mask) == idMasked &&

--- a/s2/cellunion.go
+++ b/s2/cellunion.go
@@ -49,7 +49,7 @@ func CellUnionFromRange(begin, end CellID) CellUnion {
 
 // CellUnionFromUnion creates a CellUnion from the union of the given CellUnions.
 func CellUnionFromUnion(cellUnions ...CellUnion) CellUnion {
-	var cu CellUnion
+	cu := make(CellUnion, 0, len(cellUnions))
 	for _, cellUnion := range cellUnions {
 		cu = append(cu, cellUnion...)
 	}

--- a/s2/cellunion_test.go
+++ b/s2/cellunion_test.go
@@ -349,7 +349,7 @@ func addCells(id CellID, selected bool, input *[]CellID, expected *[]CellID, t *
 		// We also make sure that we do not recurse on all 4 children, since
 		// then we might include all 4 children in the input case by accident
 		// (in which case the expected output would not be correct).
-		recurse := false
+		var recurse bool
 		if selected {
 			recurse = oneIn(12)
 		} else {

--- a/s2/cellunion_test.go
+++ b/s2/cellunion_test.go
@@ -881,7 +881,7 @@ func cellUnionDistanceFromAxis(cu CellUnion, axis Point) float64 {
 			//
 			// TODO: Improve edgeutil's DistanceFromSegment accuracy near Pi.
 			if a.Angle(axis.Vector) > math.Pi/2 || b.Angle(axis.Vector) > math.Pi/2 {
-				dist = math.Pi - float64(DistanceFromSegment(Point{axis.Mul(-1)}, a, b).Radians())
+				dist = math.Pi - DistanceFromSegment(Point{axis.Mul(-1)}, a, b).Radians()
 			} else {
 				dist = float64(a.Angle(axis.Vector))
 			}

--- a/s2/convex_hull_query.go
+++ b/s2/convex_hull_query.go
@@ -204,7 +204,7 @@ func (q *ConvexHullQuery) ConvexHull() *Loop {
 // monotoneChain iterates through the points, selecting the maximal subset of points
 // such that the edge chain makes only left (CCW) turns.
 func (q *ConvexHullQuery) monotoneChain() []Point {
-	var output []Point
+	output := make([]Point, 0, len(q.points))
 	for _, p := range q.points {
 		// Remove any points that would cause the chain to make a clockwise turn.
 		for len(output) >= 2 && RobustSign(output[len(output)-2], output[len(output)-1], p) != CounterClockwise {

--- a/s2/crossing_edge_query.go
+++ b/s2/crossing_edge_query.go
@@ -228,7 +228,7 @@ func (c *CrossingEdgeQuery) candidatesEdgeMap(a, b Point) EdgeMap {
 }
 
 // getCells returns the set of ShapeIndexCells that might contain edges intersecting
-// the edge AB in the given cell root. This method is used primarly by loop and shapeutil.
+// the edge AB in the given cell root. This method is used primarily by loop and shapeutil.
 func (c *CrossingEdgeQuery) getCells(a, b Point, root *PaddedCell) []*ShapeIndexCell {
 	aUV, bUV, ok := ClipToFace(a, b, root.id.Face())
 	if ok {

--- a/s2/crossing_edge_query.go
+++ b/s2/crossing_edge_query.go
@@ -120,14 +120,12 @@ func (c *CrossingEdgeQuery) CrossingsEdgeMap(a, b Point, crossType CrossingType)
 // candidates returns a superset of the edges of the given shape that intersect
 // the edge AB.
 func (c *CrossingEdgeQuery) candidates(a, b Point, shape Shape) []int {
-	var edges []int
-
 	// For small loops it is faster to use brute force. The threshold below was
 	// determined using benchmarks.
 	const maxBruteForceEdges = 27
 	maxEdges := shape.NumEdges()
 	if maxEdges <= maxBruteForceEdges {
-		edges = make([]int, maxEdges)
+		edges := make([]int, maxEdges)
 		for i := 0; i < maxEdges; i++ {
 			edges[i] = i
 		}
@@ -150,6 +148,8 @@ func (c *CrossingEdgeQuery) candidates(a, b Point, shape Shape) []int {
 		}
 	}
 
+	//nolint:prealloc
+	var edges []int
 	for _, cell := range c.cells {
 		clipped := cell.findByShapeID(shapeID)
 		if clipped == nil {
@@ -167,6 +167,7 @@ func (c *CrossingEdgeQuery) candidates(a, b Point, shape Shape) []int {
 
 // uniqueInts returns the sorted uniqued values from the given input.
 func uniqueInts(in []int) []int {
+	//nolint:prealloc
 	var edges []int
 	m := make(map[int]bool)
 	for _, i := range in {

--- a/s2/crossing_edge_query.go
+++ b/s2/crossing_edge_query.go
@@ -151,8 +151,6 @@ func (c *CrossingEdgeQuery) candidates(a, b Point, shape Shape) []int {
 	}
 
 	for _, cell := range c.cells {
-		if cell == nil {
-		}
 		clipped := cell.findByShapeID(shapeID)
 		if clipped == nil {
 			continue

--- a/s2/crossing_edge_query.go
+++ b/s2/crossing_edge_query.go
@@ -155,9 +155,7 @@ func (c *CrossingEdgeQuery) candidates(a, b Point, shape Shape) []int {
 		if clipped == nil {
 			continue
 		}
-		for _, j := range clipped.edges {
-			edges = append(edges, j)
-		}
+		edges = append(edges, clipped.edges...)
 	}
 
 	if len(c.cells) > 1 {
@@ -188,7 +186,7 @@ func uniqueInts(in []int) []int {
 // CAVEAT: This method may return shapes that have an empty set of candidate edges.
 // However the return value is non-empty only if at least one shape has a candidate edge.
 func (c *CrossingEdgeQuery) candidatesEdgeMap(a, b Point) EdgeMap {
-	edgeMap := make(EdgeMap, 0)
+	edgeMap := make(EdgeMap)
 
 	// If there are only a few edges then it's faster to use brute force. We
 	// only bother with this optimization when there is a single shape.

--- a/s2/edge_clipping.go
+++ b/s2/edge_clipping.go
@@ -549,7 +549,7 @@ func FaceSegments(a, b Point) []FaceSegment {
 		// Complete the current segment by finding the point where AB
 		// exits the current face.
 		z := faceXYZtoUVW(face, ab)
-		n := pointUVW{z.Vector}
+		n := pointUVW(z)
 
 		exitAxis := n.exitAxis()
 		segment.b = n.exitPoint(exitAxis)
@@ -590,7 +590,7 @@ func moveOriginToValidFace(face int, a, ab Point, aUV r2.Point) (int, r2.Point) 
 
 	// Otherwise check whether the normal AB even intersects this face.
 	z := faceXYZtoUVW(face, ab)
-	n := pointUVW{z.Vector}
+	n := pointUVW(z)
 	if n.intersectsFace() {
 		// Check whether the point where the line AB exits this face is on the
 		// wrong side of A (by more than the acceptable error tolerance).

--- a/s2/edge_distances.go
+++ b/s2/edge_distances.go
@@ -356,15 +356,18 @@ func EdgePairClosestPoints(a0, a1, b0, b1 Point) (Point, Point) {
 	var minDist s1.ChordAngle
 	var ok bool
 
-	minDist, ok = updateMinDistance(a0, b0, b1, minDist, true)
+	minDist, _ = updateMinDistance(a0, b0, b1, minDist, true)
 	closestVertex := 0
-	if minDist, ok = UpdateMinDistance(a1, b0, b1, minDist); ok {
+	minDist, ok = UpdateMinDistance(a1, b0, b1, minDist)
+	if ok {
 		closestVertex = 1
 	}
-	if minDist, ok = UpdateMinDistance(b0, a0, a1, minDist); ok {
+	minDist, ok = UpdateMinDistance(b0, a0, a1, minDist)
+	if ok {
 		closestVertex = 2
 	}
-	if minDist, ok = UpdateMinDistance(b1, a0, a1, minDist); ok {
+	_, ok = UpdateMinDistance(b1, a0, a1, minDist)
+	if ok {
 		closestVertex = 3
 	}
 	switch closestVertex {

--- a/s2/encode_test.go
+++ b/s2/encode_test.go
@@ -297,7 +297,10 @@ func TestLoopEncodeDecode(t *testing.T) {
 	loops := []*Loop{LoopFromPoints(pts), EmptyLoop(), FullLoop()}
 	for i, l := range loops {
 		var buf bytes.Buffer
-		l.Encode(&buf)
+		if err := l.Encode(&buf); err != nil {
+			t.Errorf("Encode %d: %v", i, err)
+			continue
+		}
 		ll := new(Loop)
 		if err := ll.Decode(&buf); err != nil {
 			t.Errorf("Decode %d: %v", i, err)

--- a/s2/interleave_test.go
+++ b/s2/interleave_test.go
@@ -19,7 +19,7 @@ import "testing"
 func TestInterleaveUint32(t *testing.T) {
 	x, y := uint32(13356), uint32(1073728367)
 	gotX, gotY := deinterleaveUint32(interleaveUint32(x, y))
-	if gotX != x || gotY != gotY {
+	if gotX != x || gotY != y {
 		t.Errorf("deinterleave after interleave = %d, %d; want %d, %d", gotX, gotY, x, y)
 	}
 }

--- a/s2/loop.go
+++ b/s2/loop.go
@@ -1092,7 +1092,7 @@ func (l *Loop) surfaceIntegralPoint(f func(a, b, c Point) Point) Point {
 // the loop. The return value is between 0 and 4*pi. (Note that the return
 // value is not affected by whether this loop is a "hole" or a "shell".)
 func (l *Loop) Area() float64 {
-	// It is suprisingly difficult to compute the area of a loop robustly. The
+	// It is surprisingly difficult to compute the area of a loop robustly. The
 	// main issues are (1) whether degenerate loops are considered to be CCW or
 	// not (i.e., whether their area is close to 0 or 4*pi), and (2) computing
 	// the areas of small loops with good relative accuracy.

--- a/s2/loop.go
+++ b/s2/loop.go
@@ -876,7 +876,7 @@ func (l *Loop) Invert() {
 	}
 
 	// originInside must be set correctly before building the ShapeIndex.
-	l.originInside = l.originInside != true
+	l.originInside = !l.originInside
 	if l.bound.Lat.Lo > -math.Pi/2 && l.bound.Lat.Hi < math.Pi/2 {
 		// The complement of this loop contains both poles.
 		l.bound = FullRect()

--- a/s2/loop_test.go
+++ b/s2/loop_test.go
@@ -621,7 +621,7 @@ func TestLoopFromCell(t *testing.T) {
 	// Demonstrates the reason for this test; the cell bounds are more
 	// conservative than the resulting loop bounds.
 	if loopFromCell.RectBound().Contains(cell.RectBound()) {
-		t.Errorf("loopFromCell's RectBound countains the original cells RectBound, but should not")
+		t.Errorf("loopFromCell's RectBound contains the original cells RectBound, but should not")
 	}
 }
 

--- a/s2/paddedcell.go
+++ b/s2/paddedcell.go
@@ -243,7 +243,7 @@ func (p *PaddedCell) ShrinkToFit(rect r2.Rect) CellID {
 	// if both pairs of endpoints are equal we choose maxLevel; if they differ
 	// only at bit 0, we choose (maxLevel - 1), and so on.
 	levelMSB := uint64(((iXor | jXor) << 1) + 1)
-	level := maxLevel - int(findMSBSetNonZero64(levelMSB))
+	level := maxLevel - findMSBSetNonZero64(levelMSB)
 	if level <= p.level {
 		return p.id
 	}

--- a/s2/predicates.go
+++ b/s2/predicates.go
@@ -79,8 +79,8 @@ type Direction int
 // These are the three options for the direction of a set of points.
 const (
 	Clockwise        Direction = -1
-	Indeterminate              = 0
-	CounterClockwise           = 1
+	Indeterminate    Direction = 0
+	CounterClockwise Direction = 1
 )
 
 // newBigFloat constructs a new big.Float with maximum precision.

--- a/s2/predicates.go
+++ b/s2/predicates.go
@@ -228,7 +228,7 @@ func expensiveSign(a, b, c Point) Direction {
 	// the three points are truly collinear (e.g., three points on the equator).
 	detSign := stableSign(a, b, c)
 	if detSign != Indeterminate {
-		return Direction(detSign)
+		return detSign
 	}
 
 	// Otherwise fall back to exact arithmetic and symbolic permutations.
@@ -240,7 +240,7 @@ func expensiveSign(a, b, c Point) Direction {
 func exactSign(a, b, c Point, perturb bool) Direction {
 	// Sort the three points in lexicographic order, keeping track of the sign
 	// of the permutation. (Each exchange inverts the sign of the determinant.)
-	permSign := Direction(CounterClockwise)
+	permSign := CounterClockwise
 	pa := &a
 	pb := &b
 	pc := &c
@@ -275,7 +275,7 @@ func exactSign(a, b, c Point, perturb bool) Direction {
 		// sign of the determinant.
 		detSign = symbolicallyPerturbedSign(xa, xb, xc, xbCrossXc)
 	}
-	return permSign * Direction(detSign)
+	return permSign * detSign
 }
 
 // symbolicallyPerturbedSign reports the sign of the determinant of three points

--- a/s2/rect.go
+++ b/s2/rect.go
@@ -220,7 +220,7 @@ func (r Rect) Intersects(other Rect) bool {
 	return r.Lat.Intersects(other.Lat) && r.Lng.Intersects(other.Lng)
 }
 
-// CapBound returns a cap that countains Rect.
+// CapBound returns a cap that contains Rect.
 func (r Rect) CapBound() Cap {
 	// We consider two possible bounding caps, one whose axis passes
 	// through the center of the lat-long rectangle and one whose axis

--- a/s2/rect.go
+++ b/s2/rect.go
@@ -458,7 +458,6 @@ func (r *Rect) decode(d *decoder) {
 	r.Lat.Hi = d.readFloat64()
 	r.Lng.Lo = d.readFloat64()
 	r.Lng.Hi = d.readFloat64()
-	return
 }
 
 // DistanceToLatLng returns the minimum distance (measured along the surface of the sphere)

--- a/s2/regioncoverer.go
+++ b/s2/regioncoverer.go
@@ -94,7 +94,7 @@ type candidate struct {
 	terminal    bool         // Cell should not be expanded further.
 	numChildren int          // Number of children that intersect the region.
 	children    []*candidate // Actual size may be 0, 4, 16, or 64 elements.
-	priority    int          // Priority of the candiate.
+	priority    int          // Priority of the candidate.
 }
 
 type priorityQueue []*candidate

--- a/s2/regioncoverer_test.go
+++ b/s2/regioncoverer_test.go
@@ -123,7 +123,7 @@ func TestCovererRandomCaps(t *testing.T) {
 			rc.MaxLevel = int(rand.Int31n(maxLevel + 1))
 		}
 		rc.LevelMod = int(1 + rand.Int31n(3))
-		rc.MaxCells = int(skewedInt(10))
+		rc.MaxCells = skewedInt(10)
 
 		maxArea := math.Min(4*math.Pi, float64(3*rc.MaxCells+1)*AvgAreaMetric.Value(rc.MinLevel))
 		r := Region(randomCap(0.1*AvgAreaMetric.Value(maxLevel), maxArea))

--- a/s2/s2_test_test.go
+++ b/s2/s2_test_test.go
@@ -168,7 +168,7 @@ func TestTestingFractal(t *testing.T) {
 		if got, want := loop.NumVertices(), numVerticesAtLevel(test.maxLevel); got > want {
 			t.Errorf("%s. number of vertices = %d, should be less than %d", test.label, got, want)
 		}
-		if got, want := float64(expectedNumVertices), float64(loop.NumVertices()); !float64Near(got, want, relativeError*(expectedNumVertices-float64(minVertices))) {
+		if got, want := expectedNumVertices, float64(loop.NumVertices()); !float64Near(got, want, relativeError*(expectedNumVertices-float64(minVertices))) {
 			t.Errorf("%s. expected number of vertices %v should be close to %v, difference: %v", test.label, got, want, (got - want))
 		}
 

--- a/s2/shapeindex.go
+++ b/s2/shapeindex.go
@@ -894,7 +894,6 @@ func (s *ShapeIndex) addFaceEdge(fe faceEdge, allEdges [][]faceEdge) {
 			allEdges[face] = append(allEdges[face], fe)
 		}
 	}
-	return
 }
 
 // updateFaceEdges adds or removes the various edges from the index.

--- a/s2/shapeindex.go
+++ b/s2/shapeindex.go
@@ -1450,6 +1450,7 @@ func (s *ShapeIndex) absorbIndexCell(p *PaddedCell, iter *ShapeIndexIterator, ed
 	}
 
 	// Update the edge list and delete this cell from the index.
+	//nolint:ineffassign
 	edges, newEdges = newEdges, edges
 	delete(s.cellMap, p.id)
 	// TODO(roberts): delete from s.Cells
@@ -1471,7 +1472,7 @@ func (s *ShapeIndex) countShapes(edges []*clippedEdge, shapeIDs []int32) int {
 	lastShapeID := int32(-1)
 
 	// next clipped shape id in the shapeIDs list.
-	clippedNext := int32(0)
+	var clippedNext int32
 	// index of the current element in the shapeIDs list.
 	shapeIDidx := 0
 	for _, edge := range edges {

--- a/s2/shapeindex.go
+++ b/s2/shapeindex.go
@@ -1009,6 +1009,7 @@ func (s *ShapeIndex) updateEdges(pcell *PaddedCell, edges []*clippedEdge, t *tra
 		// the existing cell contents by absorbing the cell.
 		iter := s.Iterator()
 		r := iter.LocateCellID(pcell.id)
+		//nolint:staticcheck
 		if r == Disjoint {
 			disjointFromIndex = true
 		} else if r == Indexed {
@@ -1339,6 +1340,7 @@ func (s *ShapeIndex) clipVAxis(edge *clippedEdge, middle r1.Interval) (a, b *cli
 // and/or "tracker", and then delete this cell from the index. If edges includes
 // any edges that are being removed, this method also updates their
 // InteriorTracker state to correspond to the exit vertex of this cell.
+//nolint:staticcheck
 func (s *ShapeIndex) absorbIndexCell(p *PaddedCell, iter *ShapeIndexIterator, edges []*clippedEdge, t *tracker) {
 	// When we absorb a cell, we erase all the edges that are being removed.
 	// However when we are finished with this cell, we want to restore the state

--- a/s2/shapeindex.go
+++ b/s2/shapeindex.go
@@ -1188,7 +1188,7 @@ func (s *ShapeIndex) makeIndexCell(p *PaddedCell, edges []*clippedEdge, t *track
 		var clipped *clippedShape
 		// advance to next value base + i
 		eshapeID := int32(s.Len())
-		cshapeID := int32(eshapeID) // Sentinels
+		cshapeID := eshapeID // Sentinels
 
 		if eNext != len(edges) {
 			eshapeID = edges[eNext].faceEdge.shapeID
@@ -1496,7 +1496,7 @@ func (s *ShapeIndex) countShapes(edges []*clippedEdge, shapeIDs []int32) int {
 	}
 
 	// Count any remaining containing shapes.
-	count += int(len(shapeIDs)) - int(shapeIDidx)
+	count += len(shapeIDs) - shapeIDidx
 	return count
 }
 

--- a/s2/shapeindex.go
+++ b/s2/shapeindex.go
@@ -1431,7 +1431,7 @@ func (s *ShapeIndex) absorbIndexCell(p *PaddedCell, iter *ShapeIndexIterator, ed
 		}
 	}
 	// Now create a clippedEdge for each faceEdge, and put them in "new_edges".
-	var newEdges []*clippedEdge
+	newEdges := make([]*clippedEdge, 0, len(faceEdges))
 	for _, faceEdge := range faceEdges {
 		clipped := &clippedEdge{
 			faceEdge: faceEdge,

--- a/s2/stuv_test.go
+++ b/s2/stuv_test.go
@@ -269,11 +269,11 @@ func TestXYZToFaceSiTi(t *testing.T) {
 			// levels, or not at a valid level at all (for example, si == 0).
 			faceRandom := randomUniformInt(numFaces)
 			mask := -1 << uint32(maxLevel-level)
-			siRandom := uint32(randomUint32() & uint32(mask))
-			tiRandom := uint32(randomUint32() & uint32(mask))
+			siRandom := randomUint32() & uint32(mask)
+			tiRandom := randomUint32() & uint32(mask)
 			for siRandom > maxSiTi || tiRandom > maxSiTi {
-				siRandom = uint32(randomUint32() & uint32(mask))
-				tiRandom = uint32(randomUint32() & uint32(mask))
+				siRandom = randomUint32() & uint32(mask)
+				tiRandom = randomUint32() & uint32(mask)
 			}
 
 			pRandom := faceSiTiToXYZ(faceRandom, siRandom, tiRandom)

--- a/s2/textformat_test.go
+++ b/s2/textformat_test.go
@@ -96,6 +96,7 @@ func pointsToString(points []Point) string {
 
 // parseLatLngs returns the values in the input string as LatLngs.
 func parseLatLngs(s string) []LatLng {
+	//nolint:prealloc
 	var lls []LatLng
 	if s == "" {
 		return lls
@@ -173,6 +174,7 @@ func makeLoop(s string) *Loop {
 //     "empty"  // the empty polygon (consisting of no loops)
 //     "full"   // the full polygon (consisting of one full loop)
 func makePolygon(s string, normalize bool) *Polygon {
+	//nolint:prealloc
 	var loops []*Loop
 	// Avoid the case where strings.Split on empty string will still return
 	// one empty value, where we want no values.
@@ -264,6 +266,7 @@ func makeShapeIndex(s string) *ShapeIndex {
 
 	index := NewShapeIndex()
 
+	//nolint:prealloc
 	var points []Point
 	for _, p := range strings.Split(fields[0], "|") {
 		p = strings.TrimSpace(p)


### PR DESCRIPTION
This PR fixes a bunch of problems identified by `golangci-lint` and adds a `.golangci.yml` file such that running `golangci-lint run` passes.

The changes are predominantly cosmetic. The (likely) real problems fixed are in the following files:

* `s2/edge_distances.go`: fix updates to `minDist`.
* `s2/interleave_test.go`: fix incorrect logic in test.
* `s2/predicates.go`: fix type of `const` values.

The PR is split into a bunch of separate per-linter commits that should make it easy to cherry-pick the desired commits, if needed.

