### PR TITLE
Update cellid.go

### DIFF
--- a/s2/cellid.go
+++ b/s2/cellid.go
@@ -481,7 +481,7 @@ func (ci CellID) encode(e *encoder) {
 	e.writeUint64(uint64(ci))
 }
 
-// Decode encodes the CellID.
+// Decode decodes the CellID.
 func (ci *CellID) Decode(r io.Reader) error {
 	d := &decoder{r: asByteReader(r)}
 	ci.decode(d)


### PR DESCRIPTION
Hello!

This PR fixes a minor typo in documentation for CellID.Decode. Previously it said that the function is used to encode cell IDs.

Thank you and hope this is helpful!