### PR TITLE
ppc64le - Fix deviation in floating point values caused by FMA

### DIFF
--- a/s2/latlng.go
+++ b/s2/latlng.go
@@ -64,7 +64,7 @@ func (ll LatLng) Distance(ll2 LatLng) s1.Angle {
 	lng1, lng2 := ll.Lng.Radians(), ll2.Lng.Radians()
 	dlat := math.Sin(0.5 * (lat2 - lat1))
 	dlng := math.Sin(0.5 * (lng2 - lng1))
-	x := dlat*dlat + dlng*dlng*math.Cos(lat1)*math.Cos(lat2)
+	x := float64(dlat*dlat) + float64(dlng*dlng*math.Cos(lat1)*math.Cos(lat2))
 	return s1.Angle(2*math.Atan2(math.Sqrt(x), math.Sqrt(math.Max(0, 1-x)))) * s1.Radian
 }
 
@@ -72,7 +72,7 @@ func (ll LatLng) Distance(ll2 LatLng) s1.Angle {
 // functions. Let's see if that's really necessary before exposing the same functionality.
 
 func latitude(p Point) s1.Angle {
-	return s1.Angle(math.Atan2(p.Z, math.Sqrt(p.X*p.X+p.Y*p.Y))) * s1.Radian
+	return s1.Angle(math.Atan2(p.Z, math.Sqrt(float64(p.X*p.X)+float64(p.Y*p.Y)))) * s1.Radian
 }
 
 func longitude(p Point) s1.Angle {


### PR DESCRIPTION
This was exposed while testing CockroachDB.
Following tests from pkg/sql/opt/exec/execbuilder fail due to floating point precision differences caused by FMA:
- TestExecBuild/local/geospatial
- TestExecBuild/local-vec-off/geospatial
- TestExecBuild/local-spec-planning/geospatial
- TestExecBuild/fakedist/geospatial
- TestExecBuild/fakedist-vec-off/geospatial
- TestExecBuild/fakedist-metadata/geospatial
- TestExecBuild/fakedist-disk/geospatial
- TestExecBuild/fakedist-spec-planning/geospatial

With explicit casts in this patch, these failures are resolved.

References:
https://go.dev/ref/spec#Floating_point_operators
https://github.com/golang/go/issues/53297
https://github.com/golang/go/issues/48145
https://github.com/disintegration/gift/issues/20#issuecomment-524551797