### PR TITLE
Lint fixes.

### DIFF
--- a/s2/cellid.go
+++ b/s2/cellid.go
@@ -356,8 +356,9 @@ func CellIDFromString(s string) CellID {
 	}
 	id := CellIDFromFace(face)
 	for i := 2; i < len(s); i++ {
-		childPos := s[i] - '0'
-		if childPos < 0 || childPos > 3 {
+		var childPos byte = s[i] - '0'
+		// Bytes are non-negative.
+		if childPos > 3 {
 			return CellID(0)
 		}
 		id = id.Children()[childPos]

--- a/s2/edge_distances_test.go
+++ b/s2/edge_distances_test.go
@@ -529,7 +529,7 @@ func TestEdgeDistanceUpdateMinInteriorDistanceMaxError(t *testing.T) {
 		}
 		a1 := PointOnLine(a0, randomPoint(), length)
 
-		// TODO(ericv): The error bound holds for antipodal points, but the S2
+		// TODO(rsned): The error bound holds for antipodal points, but the S2
 		// predicates used to test the error do not support antipodal points yet.
 		if a1.Vector == a0.Mul(-1) {
 			continue
@@ -545,22 +545,25 @@ func TestEdgeDistanceUpdateMinInteriorDistanceMaxError(t *testing.T) {
 		minDist := s1.InfChordAngle()
 
 		var ok bool
-		if minDist, ok = UpdateMinInteriorDistance(x, a0, a1, minDist); !ok {
+		// TODO(rsned): The first param here should be minDist which is needed
+		// for the two commented out tests below.  When they are implemented
+		// return this to "if minDist, ok == Update...."
+		if _, ok = UpdateMinInteriorDistance(x, a0, a1, minDist); !ok {
 			iter--
 			continue
 		}
 		// TODO(rsned): Uncomment once predicates has CompareEdgeDistance
 		/*
-		   maxErr := minUpdateDistanceMaxError(minDist)
-		   if got := CompareEdgeDistance(x, a0, a1, minDist.Expanded(maxErr)); got > 0 {
-		           t.Errorf("CompareEdgeDistance(%v, %v, %v, %v) = got, want <= 0",
-		                   x, a0, a1, minDist.Expanded(maxErr), got)
+			maxErr := minUpdateDistanceMaxError(minDist)
+			if got := CompareEdgeDistance(x, a0, a1, minDist.Expanded(maxErr)); got > 0 {
+				t.Errorf("CompareEdgeDistance(%v, %v, %v, %v) = got, want <= 0",
+					x, a0, a1, minDist.Expanded(maxErr), got)
 
-		   }
-		   if got := CompareEdgeDistance(x, a0, a1, minDist.Expanded(-maxErr)); got < 0 {
-		           t.Errorf("CompareEdgeDistance(%v, %v, %v, %v) = got, want >= 0",
-		                   x, a0, a1, minDist.Expanded(-maxErr), got)
-		   }
+			}
+			if got := CompareEdgeDistance(x, a0, a1, minDist.Expanded(-maxErr)); got < 0 {
+				t.Errorf("CompareEdgeDistance(%v, %v, %v, %v) = got, want >= 0",
+					x, a0, a1, minDist.Expanded(-maxErr), got)
+			}
 		*/
 	}
 }

--- a/s2/predicates.go
+++ b/s2/predicates.go
@@ -1023,7 +1023,7 @@ func exactIntersectionOrdering(a, b, c, d, m, n r3.PreciseVector) int {
 //
 // > gappa proof.gappa
 // Results:
-//|  diff_ - diff| in [0, 1145679351550454559b-107 {7.06079e-15, 2^(-47.0091)}]
+// |  diff_ - diff| in [0, 1145679351550454559b-107 {7.06079e-15, 2^(-47.0091)}]
 //
 // >>> 1145679351550454559*2**-107/2**-52
 // 31.79898987322334


### PR DESCRIPTION
Restore check on childPos to no longer test for unreachable negative values.
Fix two lint errors.