### PR TITLE
s2: Fix simple typo (interect to intersect)

### DIFF
--- a/s2/cell_index_test.go
+++ b/s2/cell_index_test.go
@@ -214,7 +214,7 @@ func verifyCellIndexContents(t *testing.T, desc string, index *CellIndex) {
 				// Verify that the cell does not intersect the range.
 				if x.cellID.RangeMin() <= r.LimitID().Prev() &&
 					x.cellID.RangeMax() >= r.StartID() {
-					t.Errorf("%s: CellID does not interect the current range: %v <= %v && %v >= %v", desc, x.cellID.RangeMin(), r.LimitID().Prev(), x.cellID.RangeMax(), r.StartID())
+					t.Errorf("%s: CellID does not intersect the current range: %v <= %v && %v >= %v", desc, x.cellID.RangeMin(), r.LimitID().Prev(), x.cellID.RangeMax(), r.StartID())
 				}
 			}
 		}


### PR DESCRIPTION
Fixing the verifyCellIndexContents error message related to the intersect verification.

closes #124 