### PR TITLE
Changes to better support random seeds for flaky tests.

### DIFF
--- a/s2/cell_test.go
+++ b/s2/cell_test.go
@@ -569,7 +569,7 @@ func TestCellContainsPointConsistentWithS2CellIDFromPoint(t *testing.T) {
 		i2 := (i1 + 1) & 3
 		v1 := cell.Vertex(i1)
 		v2 := samplePointFromCap(CapFromCenterAngle(cell.Vertex(i2), s1.Angle(epsilon)))
-		p := Interpolate(randomFloat64(), v1, v2)
+		p := Interpolate(randomUniformFloat64(0, 1.0), v1, v2)
 		if !CellFromCellID(cellIDFromPoint(p)).ContainsPoint(p) {
 			t.Errorf("For p=%v, CellFromCellID(cellIDFromPoint(p)).ContainsPoint(p) was false", p)
 		}

--- a/s2/cell_test.go
+++ b/s2/cell_test.go
@@ -16,7 +16,6 @@ package s2
 
 import (
 	"math"
-	"math/rand"
 	"testing"
 	"unsafe"
 
@@ -560,8 +559,10 @@ func TestCellContainsPoint(t *testing.T) {
 
 func TestCellContainsPointConsistentWithS2CellIDFromPoint(t *testing.T) {
 	// About 1% flaky with a random seed.
-	// TODO: https://github.com/golang/geo/issues/120
-	rand.Seed(1)
+	// TODO(rsned): https://github.com/golang/geo/issues/120
+	// If still flaky after using new seeded random in testing,
+	// refactor to pass in a specific Source in the calls to random things here.
+	// r := rand.New(rand.NewSource(1))
 
 	// Construct many points that are nearly on a Cell edge, and verify that
 	// CellFromCellID(cellIDFromPoint(p)).Contains(p) is always true.
@@ -733,8 +734,10 @@ func maxDistanceToEdgeBruteForce(cell Cell, a, b Point) s1.ChordAngle {
 
 func TestCellDistanceToEdge(t *testing.T) {
 	// About 0.1% flaky with a random seed.
-	// TODO: https://github.com/golang/geo/issues/120
-	rand.Seed(2)
+	// TODO(rsned): https://github.com/golang/geo/issues/120
+	// If still flaky after using new seeded random in testing,
+	// refactor to pass in a specific Source in the calls to random things here.
+	// r := rand.New(rand.NewSource(1))
 
 	for iter := 0; iter < 1000; iter++ {
 		cell := CellFromCellID(randomCellID())
@@ -814,6 +817,6 @@ func TestCellMaxDistanceToCell(t *testing.T) {
 	}
 }
 
-// TODO(roberts): Differences from C++.
+// TODO(rsned): Differences from C++.
 // CellVsLoopRectBound
 // RectBoundIsLargeEnough

--- a/s2/cell_test.go
+++ b/s2/cell_test.go
@@ -558,11 +558,8 @@ func TestCellContainsPoint(t *testing.T) {
 }
 
 func TestCellContainsPointConsistentWithS2CellIDFromPoint(t *testing.T) {
-	// About 1% flaky with a random seed.
+	// TODO: Is it still about 1% flaky with a random seed.
 	// TODO(rsned): https://github.com/golang/geo/issues/120
-	// If still flaky after using new seeded random in testing,
-	// refactor to pass in a specific Source in the calls to random things here.
-	// r := rand.New(rand.NewSource(1))
 
 	// Construct many points that are nearly on a Cell edge, and verify that
 	// CellFromCellID(cellIDFromPoint(p)).Contains(p) is always true.
@@ -733,11 +730,8 @@ func maxDistanceToEdgeBruteForce(cell Cell, a, b Point) s1.ChordAngle {
 }
 
 func TestCellDistanceToEdge(t *testing.T) {
-	// About 0.1% flaky with a random seed.
+	// TODO: Is it still about 0.1% flaky with a random seed.
 	// TODO(rsned): https://github.com/golang/geo/issues/120
-	// If still flaky after using new seeded random in testing,
-	// refactor to pass in a specific Source in the calls to random things here.
-	// r := rand.New(rand.NewSource(1))
 
 	for iter := 0; iter < 1000; iter++ {
 		cell := CellFromCellID(randomCellID())

--- a/s2/cellunion_test.go
+++ b/s2/cellunion_test.go
@@ -16,7 +16,6 @@ package s2
 
 import (
 	"math"
-	"math/rand"
 	"reflect"
 	"testing"
 
@@ -370,10 +369,16 @@ func addCells(id CellID, selected bool, input *[]CellID, expected *[]CellID, t *
 	}
 }
 
+// TODO(rsned): This test case doesn't match any specific test or set of tests in
+// C++. It's also somewhat flaky. It might make sense to remove or refactor this
+// to stay more inline with what's current in C++.
+
 func TestCellUnionNormalizePseudoRandom(t *testing.T) {
 	// About 2.4% flaky with a random seed.
 	// TODO: https://github.com/golang/geo/issues/120
-	rand.Seed(2)
+	// If still flaky after using new seeded random in testing,
+	// refactor to pass in a specific Source in the calls to random things here.
+	// r := rand.New(rand.NewSource(2))
 
 	// Try a bunch of random test cases, and keep track of average statistics
 	// for normalization (to see if they agree with the analysis above).

--- a/s2/cellunion_test.go
+++ b/s2/cellunion_test.go
@@ -16,6 +16,7 @@ package s2
 
 import (
 	"math"
+	"math/rand"
 	"reflect"
 	"testing"
 
@@ -293,11 +294,11 @@ func TestCellUnion(t *testing.T) {
 }
 
 func addCells(id CellID, selected bool, input *[]CellID, expected *[]CellID, t *testing.T) {
-	// Decides whether to add "id" and/or some of its descendants to the test case.  If "selected"
-	// is true, then the region covered by "id" *must* be added to the test case (either by adding
-	// "id" itself, or some combination of its descendants, or both).  If cell ids are to the test
-	// case "input", then the corresponding expected result after simplification is added to
-	// "expected".
+	// Decides whether to add "id" and/or some of its descendants to the test case.
+	// If "selected" is true, then the region covered by "id" *must* be added to
+	// the test case (either by adding "id" itself, or some combination of its
+	// descendants, or both). If cell ids are to the test case "input", then the
+	// corresponding expected result after simplification is added to "expected".
 
 	if id == 0 {
 		// Initial call: decide whether to add cell(s) from each face.
@@ -308,8 +309,8 @@ func addCells(id CellID, selected bool, input *[]CellID, expected *[]CellID, t *
 	}
 
 	if id.IsLeaf() {
-		// The oneIn() call below ensures that the parent of a leaf cell will always be selected (if
-		// we make it that far down the hierarchy).
+		// The oneIn() call below ensures that the parent of a leaf cell will
+		// always be selected (if we make it that far down the hierarchy).
 		if selected != true {
 			t.Errorf("id IsLeaf() and not selected")
 		}
@@ -319,12 +320,14 @@ func addCells(id CellID, selected bool, input *[]CellID, expected *[]CellID, t *
 
 	// The following code ensures that the probability of selecting a cell at each level is
 	// approximately the same, i.e. we test normalization of cells at all levels.
+	// TODO(rsned): Change this probability to match
+	// absl::Bernoulli(bitgen, 1.0 / (MaxLevel - id.level()))
 	if !selected && oneIn(MaxLevel-id.Level()) {
-		//  Once a cell has been selected, the expected output is predetermined.  We then make sure
-		//  that cells are selected that will normalize to the desired output.
+		// Once a cell has been selected, the expected output is predetermined.
+		// We then make sure that cells are selected that will normalize to
+		// the desired output.
 		*expected = append(*expected, id)
 		selected = true
-
 	}
 
 	// With the rnd.OneIn() constants below, this function adds an average
@@ -339,6 +342,7 @@ func addCells(id CellID, selected bool, input *[]CellID, expected *[]CellID, t *
 		*input = append(*input, id)
 		added = true
 	}
+
 	numChildren := 0
 	for child := id.ChildBegin(); child != id.ChildEnd(); child = child.Next() {
 		// If the cell is selected, on average we recurse on 4/12 = 1/3 child.
@@ -359,23 +363,23 @@ func addCells(id CellID, selected bool, input *[]CellID, expected *[]CellID, t *
 			addCells(child, selected, input, expected, t)
 			numChildren++
 		}
+
 		// If this cell was selected but the cell itself was not added, we
 		// must ensure that all 4 children (or some combination of their
 		// descendants) are added.
-
 		if selected && !added {
 			addCells(child, selected, input, expected, t)
 		}
 	}
 }
 
-// TODO(rsned): This test case doesn't match any specific test or set of tests in
-// C++. It's also somewhat flaky. It might make sense to remove or refactor this
-// to stay more inline with what's current in C++.
-
+// TODO(rsned): This test has been split out into several smaller test cases in C++.
+// It might make sense to refactor this to stay more inline with what's current.
 func TestCellUnionNormalizePseudoRandom(t *testing.T) {
-	// TODO: Verify if it's still about 2.4% flaky with a random seed.
 	// TODO(rsned): https://github.com/golang/geo/issues/120
+	// Test is still flaky without a fixed seed. Specify one for now until
+	// issue 120 is fully resolved.
+	random = rand.New(rand.NewSource(1))
 
 	// Try a bunch of random test cases, and keep track of average statistics
 	// for normalization (to see if they agree with the analysis above).

--- a/s2/cellunion_test.go
+++ b/s2/cellunion_test.go
@@ -374,11 +374,8 @@ func addCells(id CellID, selected bool, input *[]CellID, expected *[]CellID, t *
 // to stay more inline with what's current in C++.
 
 func TestCellUnionNormalizePseudoRandom(t *testing.T) {
-	// About 2.4% flaky with a random seed.
-	// TODO: https://github.com/golang/geo/issues/120
-	// If still flaky after using new seeded random in testing,
-	// refactor to pass in a specific Source in the calls to random things here.
-	// r := rand.New(rand.NewSource(2))
+	// TODO: Verify if it's still about 2.4% flaky with a random seed.
+	// TODO(rsned): https://github.com/golang/geo/issues/120
 
 	// Try a bunch of random test cases, and keep track of average statistics
 	// for normalization (to see if they agree with the analysis above).

--- a/s2/convex_hull_query_test.go
+++ b/s2/convex_hull_query_test.go
@@ -16,7 +16,6 @@ package s2
 
 import (
 	"math"
-	"math/rand"
 	"testing"
 
 	"github.com/golang/geo/s1"
@@ -196,7 +195,9 @@ func TestConvexHullQueryLoopsAroundNorthPole(t *testing.T) {
 func TestConvexHullQueryPointsInsideHull(t *testing.T) {
 	// About 0.3% flaky with a random seed.
 	// TODO: https://github.com/golang/geo/issues/120
-	rand.Seed(1)
+	// If still flaky after using new seeded random in testing,
+	// refactor to pass in a specific Source in the calls to random things here.
+	// r := rand.New(rand.NewSource(1))
 
 	// Repeatedly build the convex hull of a set of points, then add more points
 	// inside that loop and build the convex hull again. The result should

--- a/s2/convex_hull_query_test.go
+++ b/s2/convex_hull_query_test.go
@@ -193,11 +193,8 @@ func TestConvexHullQueryLoopsAroundNorthPole(t *testing.T) {
 }
 
 func TestConvexHullQueryPointsInsideHull(t *testing.T) {
-	// About 0.3% flaky with a random seed.
-	// TODO: https://github.com/golang/geo/issues/120
-	// If still flaky after using new seeded random in testing,
-	// refactor to pass in a specific Source in the calls to random things here.
-	// r := rand.New(rand.NewSource(1))
+	// TODO: Verify if it's still about 0.3% flaky with a random seed.
+	// TODO(rsned): https://github.com/golang/geo/issues/120
 
 	// Repeatedly build the convex hull of a set of points, then add more points
 	// inside that loop and build the convex hull again. The result should
@@ -224,7 +221,7 @@ func TestConvexHullQueryPointsInsideHull(t *testing.T) {
 		// test pass reliably it means that we need to reject convex hulls whose
 		// bounding cap (when computed from a bounding rectangle) is not convex.
 		//
-		// TODO(roberts): This test can still fail (about 1 iteration in 500,000)
+		// TODO(rsned): This test can still fail (about 1 iteration in 500,000)
 		// because the Rect.CapBound implementation does not guarantee
 		// that A.Contains(B) implies A.CapBound().Contains(B.CapBound()).
 		if hull.CapBound().Height() >= 1 {

--- a/s2/edge_clipping_test.go
+++ b/s2/edge_clipping_test.go
@@ -247,11 +247,8 @@ func testClipToPaddedFace(t *testing.T, a, b Point) {
 }
 
 func TestEdgeClippingClipToPaddedFace(t *testing.T) {
-	// About 1.2% flaky with a random seed.
-	// TODO: https://github.com/golang/geo/issues/120
-	// If still flaky after using new seeded random in testing,
-	// refactor to pass in a specific Source in the calls to random things here.
-	// r := rand.New(rand.NewSource(1))
+	// TODO: Verify if it's still about 1.2% flaky with a random seed.
+	// TODO(rsned): https://github.com/golang/geo/issues/120
 
 	// Start with a few simple cases.
 	// An edge that is entirely contained within one cube face:

--- a/s2/edge_clipping_test.go
+++ b/s2/edge_clipping_test.go
@@ -17,7 +17,6 @@ package s2
 import (
 	"fmt"
 	"math"
-	"math/rand"
 	"testing"
 
 	"github.com/golang/geo/r1"
@@ -250,7 +249,9 @@ func testClipToPaddedFace(t *testing.T, a, b Point) {
 func TestEdgeClippingClipToPaddedFace(t *testing.T) {
 	// About 1.2% flaky with a random seed.
 	// TODO: https://github.com/golang/geo/issues/120
-	rand.Seed(1)
+	// If still flaky after using new seeded random in testing,
+	// refactor to pass in a specific Source in the calls to random things here.
+	// r := rand.New(rand.NewSource(1))
 
 	// Start with a few simple cases.
 	// An edge that is entirely contained within one cube face:

--- a/s2/edge_query_test.go
+++ b/s2/edge_query_test.go
@@ -242,7 +242,7 @@ func testEdgeQueryWithGenerator(t *testing.T,
 	var indexCaps []Cap
 	var indexes []*ShapeIndex
 	for i := 0; i < numIndexes; i++ {
-		// Replace with:
+		// TODO(rsned): Replace with:
 	        // r := rand.New(rand.NewSource(i))
 		rand.Seed(int64(i))
 		indexCaps = append(indexCaps, CapFromCenterAngle(randomPoint(), testCapRadius))
@@ -251,7 +251,7 @@ func testEdgeQueryWithGenerator(t *testing.T,
 	}
 
 	for i := 0; i < numQueries; i++ {
-		// Replace with:
+		// TODO(rsned): Replace with:
 	        // r := rand.New(rand.NewSource(i))
 		rand.Seed(int64(i))
 		iIndex := randomUniformInt(numIndexes)

--- a/s2/edge_query_test.go
+++ b/s2/edge_query_test.go
@@ -242,6 +242,8 @@ func testEdgeQueryWithGenerator(t *testing.T,
 	var indexCaps []Cap
 	var indexes []*ShapeIndex
 	for i := 0; i < numIndexes; i++ {
+		// Replace with:
+	        // r := rand.New(rand.NewSource(i))
 		rand.Seed(int64(i))
 		indexCaps = append(indexCaps, CapFromCenterAngle(randomPoint(), testCapRadius))
 		indexes = append(indexes, NewShapeIndex())
@@ -249,6 +251,8 @@ func testEdgeQueryWithGenerator(t *testing.T,
 	}
 
 	for i := 0; i < numQueries; i++ {
+		// Replace with:
+	        // r := rand.New(rand.NewSource(i))
 		rand.Seed(int64(i))
 		iIndex := randomUniformInt(numIndexes)
 		indexCap := indexCaps[iIndex]
@@ -332,7 +336,7 @@ func testEdgeQueryWithGenerator(t *testing.T,
 //   - If maxErrorFraction > 0, then MaxError is set to the given
 //     fraction of the index radius.
 //
-// TODO(roberts): If there is a need to benchmark Furthest as well, this will need
+// TODO(rsned): If there is a need to benchmark Furthest as well, this will need
 // some changes to not use just the Closest variants of parts.
 // Furthest isn't doing anything different under the covers than Closest, so there
 // isn't really a huge need for benchmarking both.
@@ -360,12 +364,12 @@ func benchmarkEdgeQueryFindClosest(b *testing.B, bmOpts *edgeQueryBenchmarkOptio
 		bmOpts.numIndexEdges *= 4
 		b.Run(fmt.Sprintf("%d", bmOpts.numIndexEdges),
 			func(b *testing.B) {
-				// TODO(roberts): Return value 2 here is the slice of target
+				// TODO(rsned): Return value 2 here is the slice of target
 				// ShapeIndexes. Incorporate it once ShapeIndexTargets
 				// are able to be used in tests.
 				targets, _ = generateEdgeQueryWithTargets(bmOpts, query, index)
 				for i := 0; i < b.N; i++ {
-					// TODO(roberts): In the reference C++ benchmark
+					// TODO(rsned): In the reference C++ benchmark
 					// they use the tooling to split the benchmark
 					// run iterations up into kNumIndexSamples (8)
 					// times and pause to generate a new geometry
@@ -433,6 +437,7 @@ func generateEdgeQueryWithTargets(opts *edgeQueryBenchmarkOptions, query *EdgeQu
 	const maxTargetsPerIndex = 100
 
 	// Set a specific seed to allow repeatability
+	// Replace with r := rand.New(rand.NewSource(opts.randomSeed)) and pass through.
 	rand.Seed(opts.randomSeed)
 	opts.randomSeed++
 	indexCap := CapFromCenterAngle(randomPoint(), opts.radiusKm)

--- a/s2/paddedcell_test.go
+++ b/s2/paddedcell_test.go
@@ -132,11 +132,8 @@ func TestPaddedCellEntryExitVertices(t *testing.T) {
 }
 
 func TestPaddedCellShrinkToFit(t *testing.T) {
-	// About 0.2% flaky with a random seed.
+	// TODO: Verify if it's still about 0.2% flaky with a random seed.
 	// TODO(rsned): https://github.com/golang/geo/issues/120
-	// If still flaky after using new seeded random in testing,
-	// refactor to pass in a specific Source in the calls to random things here.
-	// r := rand.New(rand.NewSource(1))
 
 	for iter := 0; iter < 1000; iter++ {
 		// Start with the desired result and work backwards.

--- a/s2/paddedcell_test.go
+++ b/s2/paddedcell_test.go
@@ -146,7 +146,7 @@ func TestPaddedCellShrinkToFit(t *testing.T) {
 		// Find the biggest rectangle that fits in "result" after padding.
 		// (These calculations ignore numerical errors.)
 		maxPadding := 0.5 * math.Min(sizeUV.X, sizeUV.Y)
-		padding := maxPadding * randomFloat64()
+		padding := maxPadding * randomUniformFloat64(0, maxPadding)
 		maxRect := resultUV.ExpandedByMargin(-padding)
 
 		// Start with a random subset of the maximum rectangle.

--- a/s2/paddedcell_test.go
+++ b/s2/paddedcell_test.go
@@ -16,7 +16,6 @@ package s2
 
 import (
 	"math"
-	"math/rand"
 	"testing"
 
 	"github.com/golang/geo/r1"
@@ -134,8 +133,10 @@ func TestPaddedCellEntryExitVertices(t *testing.T) {
 
 func TestPaddedCellShrinkToFit(t *testing.T) {
 	// About 0.2% flaky with a random seed.
-	// TODO: https://github.com/golang/geo/issues/120
-	rand.Seed(1)
+	// TODO(rsned): https://github.com/golang/geo/issues/120
+	// If still flaky after using new seeded random in testing,
+	// refactor to pass in a specific Source in the calls to random things here.
+	// r := rand.New(rand.NewSource(1))
 
 	for iter := 0; iter < 1000; iter++ {
 		// Start with the desired result and work backwards.
@@ -146,7 +147,7 @@ func TestPaddedCellShrinkToFit(t *testing.T) {
 		// Find the biggest rectangle that fits in "result" after padding.
 		// (These calculations ignore numerical errors.)
 		maxPadding := 0.5 * math.Min(sizeUV.X, sizeUV.Y)
-		padding := maxPadding * randomUniformFloat64(0, maxPadding)
+		padding := randomUniformFloat64(0, maxPadding)
 		maxRect := resultUV.ExpandedByMargin(-padding)
 
 		// Start with a random subset of the maximum rectangle.

--- a/s2/point_test.go
+++ b/s2/point_test.go
@@ -94,11 +94,8 @@ func TestPointDistance(t *testing.T) {
 }
 
 func TestChordAngleBetweenPoints(t *testing.T) {
-	// About 0.2% flaky with a random seed.
-	// TODO: https://github.com/golang/geo/issues/120
-	// If still flaky after using new seeded random in testing,
-	// refactor to pass in a specific Source in the calls to random things here.
-	// r := rand.New(rand.NewSource(1))
+	// TODO: Verify if it's still about 0.2% flaky with a random seed.
+	// TODO(rsned): https://github.com/golang/geo/issues/120
 
 	for iter := 0; iter < 100; iter++ {
 		m := randomFrame()

--- a/s2/point_test.go
+++ b/s2/point_test.go
@@ -16,7 +16,6 @@ package s2
 
 import (
 	"math"
-	"math/rand"
 	"testing"
 
 	"github.com/golang/geo/r3"
@@ -97,9 +96,11 @@ func TestPointDistance(t *testing.T) {
 func TestChordAngleBetweenPoints(t *testing.T) {
 	// About 0.2% flaky with a random seed.
 	// TODO: https://github.com/golang/geo/issues/120
-	rand.Seed(1)
+	// If still flaky after using new seeded random in testing,
+	// refactor to pass in a specific Source in the calls to random things here.
+	// r := rand.New(rand.NewSource(1))
 
-	for iter := 0; iter < 10; iter++ {
+	for iter := 0; iter < 100; iter++ {
 		m := randomFrame()
 		x := m.col(0)
 		y := m.col(1)

--- a/s2/point_vector_test.go
+++ b/s2/point_vector_test.go
@@ -15,7 +15,6 @@
 package s2
 
 import (
-	"math/rand"
 	"testing"
 )
 
@@ -43,9 +42,6 @@ func TestPointVectorEmpty(t *testing.T) {
 }
 
 func TestPointVectorBasics(t *testing.T) {
-	const seed = 8675309
-	rand.Seed(seed)
-
 	const numPoints = 100
 	var p PointVector = make([]Point, numPoints)
 
@@ -70,7 +66,6 @@ func TestPointVectorBasics(t *testing.T) {
 		t.Errorf("shape.IsFull() = true, want false")
 	}
 
-	rand.Seed(seed)
 	for i := 0; i < numPoints; i++ {
 		if got, want := shape.Chain(i).Start, i; got != want {
 			t.Errorf("shape.Chain(%d).Start = %d, want %d", i, got, want)
@@ -79,7 +74,7 @@ func TestPointVectorBasics(t *testing.T) {
 			t.Errorf("shape.Chain(%d).Length = %v, want %d", i, got, want)
 		}
 		edge := shape.Edge(i)
-		pt := randomPoint()
+		pt := p[i]
 
 		if !pt.ApproxEqual(edge.V0) {
 			t.Errorf("shape.Edge(%d).V0 = %v, want %v", i, edge.V0, pt)
@@ -89,3 +84,7 @@ func TestPointVectorBasics(t *testing.T) {
 		}
 	}
 }
+
+// TODO(rsned): Differences from C++
+// TEST(S2PointVectorShape, ChainIteratorWorks) {
+// TEST(S2PointVectorShape, ChainVertexIteratorWorks) {

--- a/s2/rect.go
+++ b/s2/rect.go
@@ -31,6 +31,7 @@ type Rect struct {
 }
 
 var (
+	// TODO(rsned): Make these public to match FullLat/FullLng from C++
 	validRectLatRange = r1.Interval{Lo: -math.Pi / 2, Hi: math.Pi / 2}
 	validRectLngRange = s1.FullInterval()
 )

--- a/s2/rect_test.go
+++ b/s2/rect_test.go
@@ -1204,5 +1204,5 @@ func TestRectCentroidFullRange(t *testing.T) {
 	// the centroids of the pieces add to give the centroid of their parent.
 	// To make the code simpler we avoid rectangles that cross the 180 degree
 	// line of longitude.
-	testRectCentroidSplitting(t, Rect{r1.Interval{Lo: -math.Pi / 2, Hi: math.Pi / 2}, s1.Interval{Lo: -math.Pi, Hi: math.Pi}}, 10)
+	testRectCentroidSplitting(t, Rect{validRectLatRange, s1.Interval{Lo: -3.14, Hi: 3.14}}, 10)
 }

--- a/s2/s2_test.go
+++ b/s2/s2_test.go
@@ -49,7 +49,7 @@ const (
 var (
 	// set up a random generator for use in tests.
 	// Prior to Go 1.20, the generator was seeded like Seed(1) at program startup.
-	// Using the default see flag value will produce the prior behavior.
+	// Using the default seed flag value will produce the prior behavior.
 	random = rand.New(rand.NewSource(*s2RandomSeed))
 )
 

--- a/s2/s2_test.go
+++ b/s2/s2_test.go
@@ -386,6 +386,8 @@ func perturbedCornerOrMidpoint(p, q Point, r ...*rand.Rand) Point {
 		// This perturbation often has no effect except on coordinates that are
 		// zero, in which case the perturbed value is so small that operations on
 		// it often result in underflow.
+		// TODO(rsned): Change this to
+		// a += s2random::LogUniform(bitgen, 1e-300, 1.0) * s2random::Point(bitgen);
 		a = a.Add(randomPoint(r...).Mul(math.Pow(1e-300, randomFloat64(r...))))
 	} else if oneIn(2) {
 		// For coordinates near 1 (say > 0.5), this perturbation yields values
@@ -393,12 +395,14 @@ func perturbedCornerOrMidpoint(p, q Point, r ...*rand.Rand) Point {
 		a = a.Add(randomPoint(r...).Mul(4 * dblEpsilon))
 	} else {
 		// A perturbation whose magnitude is in the range [1e-25, 1e-10].
+		// TODO(rsned): Change this to
+		// a += s2random::LogUniform(bitgen, 1e-25, 1e-10) * s2random::Point(bitgen);
 		a = a.Add(randomPoint(r...).Mul(1e-10 * math.Pow(1e-15, randomFloat64(r...))))
 	}
 
 	if a.Norm2() < math.SmallestNonzeroFloat64 {
 		// If a.Norm2() is denormalized, Normalize() loses too much precision.
-		return perturbedCornerOrMidpoint(p, q)
+		return perturbedCornerOrMidpoint(p, q, r...)
 	}
 	return Point{a}
 }

--- a/s2/s2_test.go
+++ b/s2/s2_test.go
@@ -31,6 +31,11 @@ var (
 	// When using blaze/bazel add "--test_arg=--benchmark_brute_force=true"
 	benchmarkBruteForce = flag.Bool("benchmark_brute_force", false,
 		"When set, use brute force algorithms in benchmarking.")
+
+	// To set in go testing add "--s2_random_seed=123" to your test command.
+	// When using blaze/bazel add "--test_arg=--s2_random_seed=123"
+	s2RandomSeed = flag.Int("s2_random_seed", 1,
+		"Seed value that can be used in testing and benchmarks.")
 )
 
 const (

--- a/s2/s2_test.go
+++ b/s2/s2_test.go
@@ -34,7 +34,7 @@ var (
 
 	// To set in go testing add "--s2_random_seed=123" to your test command.
 	// When using blaze/bazel add "--test_arg=--s2_random_seed=123"
-	s2RandomSeed = flag.Int("s2_random_seed", 1,
+	s2RandomSeed = flag.Int64("s2_random_seed", 1,
 		"Seed value that can be used in testing and benchmarks.")
 )
 
@@ -46,6 +46,13 @@ const (
 	epsilon = 1e-15
 )
 
+var (
+	// set up a random generator for use in tests.
+	// Prior to Go 1.20, the generator was seeded like Seed(1) at program startup.
+	// Using the default see flag value will produce the prior behavior.
+	random = rand.New(rand.NewSource(*s2RandomSeed))
+)
+
 // float64Eq reports whether the two values are within the default epsilon.
 func float64Eq(x, y float64) bool { return float64Near(x, y, epsilon) }
 
@@ -53,8 +60,6 @@ func float64Eq(x, y float64) bool { return float64Near(x, y, epsilon) }
 func float64Near(x, y, ε float64) bool {
 	return math.Abs(x-y) <= ε
 }
-
-// TODO(roberts): Add in flag to allow specifying the random seed for repeatable tests.
 
 // The Earth's mean radius in kilometers (according to NASA).
 const earthRadiusKm = 6371.01
@@ -66,66 +71,75 @@ func kmToAngle(km float64) s1.Angle {
 
 // randomBits returns a 64-bit random unsigned integer whose lowest "num" are random, and
 // whose other bits are zero.
-func randomBits(num uint32) uint64 {
+func randomBits(num uint32, r ...*rand.Rand) uint64 {
+	rnd := random
+	if len(r) > 0 {
+		rnd = r[0]
+	}
 	// Make sure the request is for not more than 63 bits.
 	if num > 63 {
 		num = 63
 	}
-	return uint64(rand.Int63()) & ((1 << num) - 1)
+	return uint64(rnd.Int63()) & ((1 << num) - 1)
 }
 
 // Return a uniformly distributed 64-bit unsigned integer.
-func randomUint64() uint64 {
-	return uint64(rand.Int63() | (rand.Int63() << 63))
+func randomUint64(r ...*rand.Rand) uint64 {
+	rnd := random
+	if len(r) > 0 {
+		rnd = r[0]
+	}
+
+	return uint64(rnd.Int63() | (rnd.Int63() << 63))
 }
 
 // Return a uniformly distributed 32-bit unsigned integer.
-func randomUint32() uint32 {
-	return uint32(randomBits(32))
+func randomUint32(r ...*rand.Rand) uint32 {
+	return uint32(randomBits(32, r...))
 }
 
 // randomFloat64 returns a uniformly distributed value in the range [0,1).
 // Note that the values returned are all multiples of 2**-53, which means that
 // not all possible values in this range are returned.
-func randomFloat64() float64 {
+func randomFloat64(r ...*rand.Rand) float64 {
 	const randomFloatBits = 53
-	return math.Ldexp(float64(randomBits(randomFloatBits)), -randomFloatBits)
+	return math.Ldexp(float64(randomBits(randomFloatBits, r...)), -randomFloatBits)
 }
 
 // randomUniformInt returns a uniformly distributed integer in the range [0,n).
 // NOTE: This is replicated here to stay in sync with how the C++ code generates
 // uniform randoms. (instead of using Go's math/rand package directly).
-func randomUniformInt(n int) int {
-	return int(randomFloat64() * float64(n))
+func randomUniformInt(n int, r ...*rand.Rand) int {
+	return int(randomFloat64(r...) * float64(n))
 }
 
 // randomUniformFloat64 returns a uniformly distributed value in the range [min, max).
-func randomUniformFloat64(min, max float64) float64 {
-	return min + randomFloat64()*(max-min)
+func randomUniformFloat64(min, max float64, r ...*rand.Rand) float64 {
+	return min + randomFloat64(r...)*(max-min)
 }
 
 // oneIn returns true with a probability of 1/n.
-func oneIn(n int) bool {
-	return randomUniformInt(n) == 0
+func oneIn(n int, r ...*rand.Rand) bool {
+	return randomUniformInt(n, r...) == 0
 }
 
 // randomPoint returns a random unit-length vector.
-func randomPoint() Point {
-	return PointFromCoords(randomUniformFloat64(-1, 1),
-		randomUniformFloat64(-1, 1), randomUniformFloat64(-1, 1))
+func randomPoint(r ...*rand.Rand) Point {
+	return PointFromCoords(randomUniformFloat64(-1, 1, r...),
+		randomUniformFloat64(-1, 1, r...), randomUniformFloat64(-1, 1, r...))
 }
 
 // randomFrame returns a right-handed coordinate frame (three orthonormal vectors) for
 // a randomly generated point.
-func randomFrame() *matrix3x3 {
-	return randomFrameAtPoint(randomPoint())
+func randomFrame(r ...*rand.Rand) *matrix3x3 {
+	return randomFrameAtPoint(randomPoint(r...))
 }
 
 // randomFrameAtPoint returns a right-handed coordinate frame using the given
 // point as the z-axis. The x- and y-axes are computed such that (x,y,z) is a
 // right-handed coordinate frame (three orthonormal vectors).
-func randomFrameAtPoint(z Point) *matrix3x3 {
-	x := Point{z.Cross(randomPoint().Vector).Normalize()}
+func randomFrameAtPoint(z Point, r ...*rand.Rand) *matrix3x3 {
+	x := Point{z.Cross(randomPoint(r...).Vector).Normalize()}
 	y := Point{z.Cross(x.Vector).Normalize()}
 
 	m := &matrix3x3{}
@@ -138,24 +152,24 @@ func randomFrameAtPoint(z Point) *matrix3x3 {
 // randomCellIDForLevel returns a random CellID at the given level.
 // The distribution is uniform over the space of cell ids, but only
 // approximately uniform over the surface of the sphere.
-func randomCellIDForLevel(level int) CellID {
-	face := randomUniformInt(NumFaces)
-	pos := randomUint64() & uint64((1<<PosBits)-1)
+func randomCellIDForLevel(level int, r ...*rand.Rand) CellID {
+	face := randomUniformInt(NumFaces, r...)
+	pos := randomUint64(r...) & uint64((1<<PosBits)-1)
 	return CellIDFromFacePosLevel(face, pos, level)
 }
 
 // randomCellID returns a random CellID at a randomly chosen
 // level. The distribution is uniform over the space of cell ids,
 // but only approximately uniform over the surface of the sphere.
-func randomCellID() CellID {
-	return randomCellIDForLevel(randomUniformInt(MaxLevel + 1))
+func randomCellID(r ...*rand.Rand) CellID {
+	return randomCellIDForLevel(randomUniformInt(MaxLevel+1), r...)
 }
 
 // randomCellUnion returns a CellUnion of the given size of randomly selected cells.
-func randomCellUnion(n int) CellUnion {
+func randomCellUnion(n int, r ...*rand.Rand) CellUnion {
 	var cu CellUnion
 	for i := 0; i < n; i++ {
-		cu = append(cu, randomCellID())
+		cu = append(cu, randomCellID(r...))
 	}
 	return cu
 }
@@ -172,17 +186,22 @@ func concentricLoopsPolygon(center Point, numLoops, verticesPerLoop int) *Polygo
 }
 
 // skewedInt returns a number in the range [0,2^max_log-1] with bias towards smaller numbers.
-func skewedInt(maxLog int) int {
-	base := uint32(rand.Int31n(int32(maxLog + 1)))
-	return int(randomBits(31) & ((1 << base) - 1))
+func skewedInt(maxLog int, r ...*rand.Rand) int {
+	rnd := random
+	if len(r) > 0 {
+		rnd = r[0]
+	}
+
+	base := uint32(rnd.Int31n(int32(maxLog + 1)))
+	return int(randomBits(31, r...) & ((1 << base) - 1))
 }
 
 // randomCap returns a cap with a random axis such that the log of its area is
 // uniformly distributed between the logs of the two given values. The log of
 // the cap angle is also approximately uniformly distributed.
-func randomCap(minArea, maxArea float64) Cap {
-	capArea := maxArea * math.Pow(minArea/maxArea, randomFloat64())
-	return CapFromCenterArea(randomPoint(), capArea)
+func randomCap(minArea, maxArea float64, r ...*rand.Rand) Cap {
+	capArea := maxArea * math.Pow(minArea/maxArea, randomFloat64(r...))
+	return CapFromCenterArea(randomPoint(r...), capArea)
 }
 
 // latLngsApproxEqual reports of the two LatLngs are within the given epsilon.
@@ -276,21 +295,21 @@ func matricesApproxEqual(m1, m2 *matrix3x3) bool {
 
 // samplePointFromRect returns a point chosen uniformly at random (with respect
 // to area on the sphere) from the given rectangle.
-func samplePointFromRect(rect Rect) Point {
+func samplePointFromRect(rect Rect, r ...*rand.Rand) Point {
 	// First choose a latitude uniformly with respect to area on the sphere.
 	sinLo := math.Sin(rect.Lat.Lo)
 	sinHi := math.Sin(rect.Lat.Hi)
-	lat := math.Asin(randomUniformFloat64(sinLo, sinHi))
+	lat := math.Asin(randomUniformFloat64(sinLo, sinHi, r...))
 
 	// Now choose longitude uniformly within the given range.
-	lng := rect.Lng.Lo + randomFloat64()*rect.Lng.Length()
+	lng := rect.Lng.Lo + randomFloat64(r...)*rect.Lng.Length()
 
 	return PointFromLatLng(LatLng{s1.Angle(lat), s1.Angle(lng)}.Normalized())
 }
 
 // samplePointFromCap returns a point chosen uniformly at random (with respect
 // to area) from the given cap.
-func samplePointFromCap(c Cap) Point {
+func samplePointFromCap(c Cap, r ...*rand.Rand) Point {
 	// We consider the cap axis to be the "z" axis. We choose two other axes to
 	// complete the coordinate frame.
 	m := getFrame(c.Center())
@@ -298,19 +317,19 @@ func samplePointFromCap(c Cap) Point {
 	// The surface area of a spherical cap is directly proportional to its
 	// height. First we choose a random height, and then we choose a random
 	// point along the circle at that height.
-	h := randomFloat64() * c.Height()
-	theta := 2 * math.Pi * randomFloat64()
-	r := math.Sqrt(h * (2 - h))
+	h := randomFloat64(r...) * c.Height()
+	theta := 2 * math.Pi * randomFloat64(r...)
+	rad := math.Sqrt(h * (2 - h))
 
 	// The result should already be very close to unit-length, but we might as
 	// well make it accurate as possible.
-	return Point{fromFrame(m, PointFromCoords(math.Cos(theta)*r, math.Sin(theta)*r, 1-h)).Normalize()}
+	return Point{fromFrame(m, PointFromCoords(math.Cos(theta)*rad, math.Sin(theta)*rad, 1-h)).Normalize()}
 }
 
 // perturbATowardsB returns a point that has been shifted some distance towards the
 // second point based on a random number.
-func perturbATowardsB(a, b Point) Point {
-	choice := randomFloat64()
+func perturbATowardsB(a, b Point, r ...*rand.Rand) Point {
+	choice := randomFloat64(r...)
 	if choice < 0.1 {
 		return a
 	}
@@ -318,7 +337,7 @@ func perturbATowardsB(a, b Point) Point {
 		// Return a point that is exactly proportional to A and that still
 		// satisfies IsUnitLength().
 		for {
-			b := Point{a.Mul(2 - a.Norm() + 5*(randomFloat64()-0.5)*dblEpsilon)}
+			b := Point{a.Mul(2 - a.Norm() + 5*(randomFloat64(r...)-0.5)*dblEpsilon)}
 			if !b.ApproxEqual(a) && b.IsUnit() {
 				return b
 			}
@@ -330,7 +349,7 @@ func perturbATowardsB(a, b Point) Point {
 	}
 	// Otherwise return a point whose distance from A is near dblEpsilon such
 	// that the log of the pdf is uniformly distributed.
-	distance := dblEpsilon * 1e-5 * math.Pow(1e6, randomFloat64())
+	distance := dblEpsilon * 1e-5 * math.Pow(1e6, randomFloat64(r...))
 	return InterpolateAtDistance(s1.Angle(distance), a, b)
 }
 
@@ -339,20 +358,20 @@ func perturbATowardsB(a, b Point) Point {
 // it returns either an edge midpoint, face midpoint, or corner vertex that is
 // in the plane of PQ and that has been perturbed slightly. It also sometimes
 // returns a random point from anywhere on the sphere.
-func perturbedCornerOrMidpoint(p, q Point) Point {
-	a := p.Mul(float64(randomUniformInt(3) - 1)).Add(q.Mul(float64(randomUniformInt(3) - 1)))
+func perturbedCornerOrMidpoint(p, q Point, r ...*rand.Rand) Point {
+	a := p.Mul(float64(randomUniformInt(3, r...) - 1)).Add(q.Mul(float64(randomUniformInt(3, r...) - 1)))
 	if oneIn(10) {
 		// This perturbation often has no effect except on coordinates that are
 		// zero, in which case the perturbed value is so small that operations on
 		// it often result in underflow.
-		a = a.Add(randomPoint().Mul(math.Pow(1e-300, randomFloat64())))
+		a = a.Add(randomPoint(r...).Mul(math.Pow(1e-300, randomFloat64(r...))))
 	} else if oneIn(2) {
 		// For coordinates near 1 (say > 0.5), this perturbation yields values
 		// that are only a few representable values away from the initial value.
-		a = a.Add(randomPoint().Mul(4 * dblEpsilon))
+		a = a.Add(randomPoint(r...).Mul(4 * dblEpsilon))
 	} else {
 		// A perturbation whose magnitude is in the range [1e-25, 1e-10].
-		a = a.Add(randomPoint().Mul(1e-10 * math.Pow(1e-15, randomFloat64())))
+		a = a.Add(randomPoint(r...).Mul(1e-10 * math.Pow(1e-15, randomFloat64(r...))))
 	}
 
 	if a.Norm2() < math.SmallestNonzeroFloat64 {

--- a/s2/s2_test_test.go
+++ b/s2/s2_test_test.go
@@ -50,11 +50,8 @@ func numVerticesAtLevel(level int) int {
 }
 
 func TestTestingFractal(t *testing.T) {
-	// About 2.4% flaky with a random seed, due to CesaroMultiFractal.
-	// TODO: https://github.com/golang/geo/issues/120
-	// If still flaky after using new seeded random in testing,
-	// refactor to pass in a specific Source in the calls to random things here.
-	// r := rand.New(rand.NewSource(1))
+	// TODO: Verify if it's about 2.4% flaky with a random seed, due to CesaroMultiFractal.
+	// TODO(rsned): https://github.com/golang/geo/issues/120
 
 	tests := []struct {
 		label     string
@@ -247,7 +244,7 @@ func TestChordAngleMaxPointError(t *testing.T) {
 	}
 }
 
-// TODO(roberts): Remaining tests
+// TODO(rsned): Remaining tests
 // TriangleFractal
 // TriangleMultiFractal
 // SpaceFillingFractal

--- a/s2/s2_test_test.go
+++ b/s2/s2_test_test.go
@@ -17,7 +17,6 @@ package s2
 import (
 	"fmt"
 	"math"
-	"math/rand"
 	"testing"
 
 	"github.com/golang/geo/s1"
@@ -53,7 +52,9 @@ func numVerticesAtLevel(level int) int {
 func TestTestingFractal(t *testing.T) {
 	// About 2.4% flaky with a random seed, due to CesaroMultiFractal.
 	// TODO: https://github.com/golang/geo/issues/120
-	rand.Seed(1)
+	// If still flaky after using new seeded random in testing,
+	// refactor to pass in a specific Source in the calls to random things here.
+	// r := rand.New(rand.NewSource(1))
 
 	tests := []struct {
 		label     string
@@ -146,7 +147,7 @@ func TestTestingFractal(t *testing.T) {
 		// can be simplified to sqrt((k-1)/n).
 		numLevels := test.maxLevel - test.minLevel + 1
 		minVertices := numVerticesAtLevel(test.minLevel)
-		relativeError := math.Sqrt((float64(numLevels) - 1.0) / float64(minVertices))
+		relativeError := 2.0 * math.Sqrt((float64(numLevels)-1.0)/float64(minVertices))
 
 		// expansionFactor is the total fractal length at level n+1 divided by
 		// the total fractal length at level n.
@@ -156,7 +157,7 @@ func TestTestingFractal(t *testing.T) {
 
 		// trianglePerim is the perimeter of the original equilateral triangle
 		// before any subdivision occurs.
-		trianglePerim := 3 * math.Sqrt(3) * math.Tan(nominalRadius)
+		trianglePerim := 3 * sqrt3 * math.Tan(nominalRadius)
 		minLengthSum := trianglePerim * math.Pow(expansionFactor, float64(test.minLevel))
 		for level := test.minLevel; level <= test.maxLevel; level++ {
 			expectedNumVertices += float64(numVerticesAtLevel(level))


### PR DESCRIPTION
Add flag (--s2_random_seed) to specify the seed used for random generation in tests.
Add new testing flag to specify the s2 random seed to allow repeatability between test runs.
Refactor random test methods to allow optional seeded generators.
Fix up all the functions in s2_test.go to take an optional random generator.
Change the places that actually generate the random values to test for the optional parameter and use it if set.
Minor fixes to a couple tests to match the current logic and values in their corresponding C++ tests. (paddedcell_test to use uniform float vs random float, fractal test cases relative error size)
Update comments on random seeds to reference current rand form.
With the addition of the random seed flag in testing now, update the comments on the cases that were triggering flaky tests. If they still show flakes, the specific cases can now be pushed through to the underlying random calls.

Fixes #120 