### PR TITLE
tests: Remove outdated flaky test comments

### DIFF
--- a/s2/convex_hull_query_test.go
+++ b/s2/convex_hull_query_test.go
@@ -193,9 +193,6 @@ func TestConvexHullQueryLoopsAroundNorthPole(t *testing.T) {
 }
 
 func TestConvexHullQueryPointsInsideHull(t *testing.T) {
-	// TODO: Verify if it's still about 0.3% flaky with a random seed.
-	// TODO(rsned): https://github.com/golang/geo/issues/120
-
 	// Repeatedly build the convex hull of a set of points, then add more points
 	// inside that loop and build the convex hull again. The result should
 	// always be the same.

--- a/s2/edge_clipping_test.go
+++ b/s2/edge_clipping_test.go
@@ -247,9 +247,6 @@ func testClipToPaddedFace(t *testing.T, a, b Point) {
 }
 
 func TestEdgeClippingClipToPaddedFace(t *testing.T) {
-	// TODO: Verify if it's still about 1.2% flaky with a random seed.
-	// TODO(rsned): https://github.com/golang/geo/issues/120
-
 	// Start with a few simple cases.
 	// An edge that is entirely contained within one cube face:
 	testClipToPaddedFace(t, Point{r3.Vector{X: 1, Y: -0.5, Z: -0.5}}, Point{r3.Vector{X: 1, Y: 0.5, Z: 0.5}})

--- a/s2/paddedcell_test.go
+++ b/s2/paddedcell_test.go
@@ -132,9 +132,6 @@ func TestPaddedCellEntryExitVertices(t *testing.T) {
 }
 
 func TestPaddedCellShrinkToFit(t *testing.T) {
-	// TODO: Verify if it's still about 0.2% flaky with a random seed.
-	// TODO(rsned): https://github.com/golang/geo/issues/120
-
 	for iter := 0; iter < 1000; iter++ {
 		// Start with the desired result and work backwards.
 		result := randomCellID()

--- a/s2/point_test.go
+++ b/s2/point_test.go
@@ -100,9 +100,6 @@ func TestPointDistance(t *testing.T) {
 }
 
 func TestChordAngleBetweenPoints(t *testing.T) {
-	// TODO: Verify if it's still about 0.2% flaky with a random seed.
-	// TODO(rsned): https://github.com/golang/geo/issues/120
-
 	for iter := 0; iter < 100; iter++ {
 		m := randomFrame()
 		x := m.col(0)

--- a/s2/s2_test_test.go
+++ b/s2/s2_test_test.go
@@ -50,9 +50,6 @@ func numVerticesAtLevel(level int) int {
 }
 
 func TestTestingFractal(t *testing.T) {
-	// TODO: Verify if it's about 2.4% flaky with a random seed, due to CesaroMultiFractal.
-	// TODO(rsned): https://github.com/golang/geo/issues/120
-
 	tests := []struct {
 		label     string
 		minLevel  int


### PR DESCRIPTION
Remove TODO from tests that are no longer flaky.  (Tested 1k times, see https://github.com/golang/geo/issues/120#issuecomment-2772252865)