### PR TITLE
go.yml: use stable go-version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version: 'stable'
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,9 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
+        # TODO: enable [matrix testing](https://github.com/marketplace/actions/setup-go-environment#matrix-testing)
+        # so that we can test on both stable, oldstable and the oldest version
+        # we currently support (as specified in go.mod).
         go-version: 'stable'
 
     - name: Build


### PR DESCRIPTION
Previously we were using the version in go.mod.  We're thinking we shouldn't update that unless we want to use new features of the latest go release.    However, for the build / test actions, it seems important to test using a version we'd recommend for our clients.

Fix #154 