### PR TITLE
dependabot.yml: Reduce github-actions update to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: gomod
     directory: /


### PR DESCRIPTION
codeql-action is updated very frequently, which is annoying.

We may want to drop this to monthly, but try weekly for now.