### PR TITLE
Correct file names in comments

### DIFF
--- a/s2/cap_test.go
+++ b/s2/cap_test.go
@@ -281,7 +281,7 @@ func TestCapRadiusToHeight(t *testing.T) {
 		{4.0 * s1.Radian, fullHeight},
 	}
 	for _, test := range tests {
-		// float64Eq comes from s2latlng_test.go
+		// float64Eq comes from latlng_test.go
 		if got := radiusToHeight(test.got); !float64Eq(got, test.want) {
 			t.Errorf("radiusToHeight(%v) = %v; want %v", test.got, got, test.want)
 		}

--- a/s2/stuv.go
+++ b/s2/stuv.go
@@ -46,7 +46,7 @@ import (
 //  (id)
 //    A CellID is a 64-bit encoding of a face and a Hilbert curve position
 //    on that face. The Hilbert curve position implicitly encodes both the
-//    position of a cell and its subdivision level (see s2cellid.go).
+//    position of a cell and its subdivision level (see cellid.go).
 //
 //  (face, i, j)
 //    Leaf-cell coordinates. "i" and "j" are integers in the range


### PR DESCRIPTION
Files were once called s2*.go, but no longer.