### PR TITLE
regularPointsForFrame: Allocate memory in one go

### DIFF
--- a/s2/point.go
+++ b/s2/point.go
@@ -160,12 +160,12 @@ func regularPointsForFrame(frame matrix3x3, radius s1.Angle, numVertices int) []
 	z := math.Cos(radius.Radians())
 	r := math.Sin(radius.Radians())
 	radianStep := 2 * math.Pi / float64(numVertices)
-	var vertices []Point
+	var vertices = make([]Point, numVertices)
 
 	for i := 0; i < numVertices; i++ {
 		angle := float64(i) * radianStep
 		p := Point{r3.Vector{X: r * math.Cos(angle), Y: r * math.Sin(angle), Z: z}}
-		vertices = append(vertices, Point{fromFrame(frame, p).Normalize()})
+		vertices[i].Vector = fromFrame(frame, p).Normalize()
 	}
 
 	return vertices

--- a/s2/point_test.go
+++ b/s2/point_test.go
@@ -458,3 +458,13 @@ func TestPointEnsureNormalizable(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkPointRegularPoints(b *testing.B) {
+	center := PointFromLatLng(LatLngFromDegrees(80, 135))
+	radius := s1.Degree * 20
+
+	for i := 0; i < b.N; i++ {
+		b.ReportAllocs()
+		regularPoints(center, radius, 8)
+	}
+}


### PR DESCRIPTION
- Before
`BenchmarkPointRegularPoints-12` 1476942	       810.5 ns/op	     360 B/op	       4 allocs/op`

- After
`BenchmarkPointRegularPoints-12 2055764	       548.6 ns/op	     192 B/op	       1 allocs/op`