### PR TITLE
dependabot.yml: Exclude codeql-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,11 @@
 version: 2
 updates:
-  # Handle everything *but* `codeql-action`.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    # Many trivial updates, so ignore and update manually.
     ignore:
-      - dependency-name: "github/codeql-action"
-
-  # Handle `codeql-action` monthly, since it has many trivial updates.
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: monthly
-    allow:
       - dependency-name: "github/codeql-action"
 
   - package-ecosystem: gomod

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,7 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
+        # Many trivial updates, so this is excluded from dependabot.yml.  Update manually.
         uses: github/codeql-action/upload-sarif@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v4.31.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
67a2e55 (dependabot.yml: Drop codeql-action frequency to monthly (#224)) attempted to drop the frequency of codeql-action updates to monthly, but resulted in an error:

```
Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'github-actions' has overlapping directories.
```

Just exclude codeql-action and we'll update it manually.