### PR TITLE
Bump required go version to 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # Test on supported go compiler releases as well as the oldest version we support from go.mod.
-        go: [ '1.21', 'oldstable', 'stable' ]
+        go: [ '1.23', 'oldstable', 'stable' ]
     name: Go version ${{ matrix.go }}
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/golang/geo
 
 // This declares what language features we use and may be updated freely up to "oldstable".
 // Update .github/workflows/go.yml when bumping this version.
-go 1.21.0
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.7.0 // indirect


### PR DESCRIPTION
1.22 introduced `range n` loops, which seem nice.

Bump to 1.23, which is one behind oldstable (the oldest we claim to support).

https://go.dev/doc/go1.22
https://go.dev/doc/go1.23