### PR TITLE
predicates: Fix stableSign underflow causing wrong RobustSign result

### DIFF
--- a/s2/predicates.go
+++ b/s2/predicates.go
@@ -40,9 +40,8 @@ const (
 	dblEpsilon = 2.220446049250313e-16
 	// dblError is the C++ value for S2 rounding_epsilon().
 	dblError = 1.110223024625156e-16
-	// dblMin is the smallest positive normal float64 value.
-	// This is the C++ DBL_MIN equivalent.
-	dblMin = 0x1p-1022
+	// smallestNormalFloat64 is the C++ DBL_MIN equivalent.
+	smallestNormalFloat64 = 0x1p-1022
 
 	// sqrt3 is used many times throughout but computed every time,
 	// so use the OEIS value like package math does for Sqrt2, etc.
@@ -228,7 +227,7 @@ func stableSign(a, b, c Point) Direction {
 	maxErr := detErrorMultiplier * math.Sqrt(e1.Norm2()*e2.Norm2())
 
 	// Errors smaller than this value may not be accurate due to underflow.
-	minNoUnderflowError := detErrorMultiplier * math.Sqrt(dblMin)
+	minNoUnderflowError := detErrorMultiplier * math.Sqrt(smallestNormalFloat64)
 	if maxErr < minNoUnderflowError {
 		return Indeterminate
 	}

--- a/s2/predicates.go
+++ b/s2/predicates.go
@@ -40,6 +40,9 @@ const (
 	dblEpsilon = 2.220446049250313e-16
 	// dblError is the C++ value for S2 rounding_epsilon().
 	dblError = 1.110223024625156e-16
+	// dblMin is the smallest positive normal float64 value.
+	// This is the C++ DBL_MIN equivalent.
+	dblMin = 0x1p-1022
 
 	// sqrt3 is used many times throughout but computed every time,
 	// so use the OEIS value like package math does for Sqrt2, etc.
@@ -223,6 +226,12 @@ func stableSign(a, b, c Point) Direction {
 
 	det := -e1.Cross(e2).Dot(op)
 	maxErr := detErrorMultiplier * math.Sqrt(e1.Norm2()*e2.Norm2())
+
+	// Errors smaller than this value may not be accurate due to underflow.
+	minNoUnderflowError := detErrorMultiplier * math.Sqrt(dblMin)
+	if maxErr < minNoUnderflowError {
+		return Indeterminate
+	}
 
 	// If the determinant isn't zero, within maxErr, we know definitively the point ordering.
 	if det > maxErr {

--- a/s2/predicates_test.go
+++ b/s2/predicates_test.go
@@ -329,6 +329,24 @@ func TestPredicatesStableSignFailureRate(t *testing.T) {
 	}
 }
 
+func TestPredicatesStableSignUnderflow(t *testing.T) {
+	// Verify that stableSign returns Indeterminate when its error calculation underflows,
+	// and that RobustSign still resolves the sign via the exact arithmetic fallback.
+	a := Point{r3.Vector{X: 1, Y: 1.9535722048627587e-90, Z: 7.4882501322554515e-80}}
+	b := Point{r3.Vector{X: 1, Y: 9.6702373087191359e-127, Z: 3.706704857169321e-116}}
+	c := Point{r3.Vector{X: 1, Y: 3.8163353663361477e-142, Z: 1.4628419538608985e-131}}
+
+	if got := stableSign(a, b, c); got != Indeterminate {
+		t.Errorf("stableSign(%v, %v, %v) = %v, want %v", a, b, c, got, Indeterminate)
+	}
+	if got := exactSign(a, b, c, true); got != CounterClockwise {
+		t.Errorf("exactSign(%v, %v, %v, true) = %v, want %v", a, b, c, got, CounterClockwise)
+	}
+	if got := RobustSign(a, b, c); got != CounterClockwise {
+		t.Errorf("RobustSign(%v, %v, %v) = %v, want %v", a, b, c, got, CounterClockwise)
+	}
+}
+
 func TestPredicatesSymbolicallyPerturbedSign(t *testing.T) {
 	// The purpose of this test is simply to get code coverage of
 	// SymbolicallyPerturbedSign().  Let M_1, M_2, ... be the sequence of
@@ -1242,7 +1260,6 @@ func BenchmarkRobustSignNearCollinear(b *testing.B) {
 // TEST(epsilon_for_digits, recursion) {
 // TEST(rounding_epsilon, vs_numeric_limits) {
 // TEST(Sign, CollinearPoints) {
-// TEST(Sign, StableSignUnderflow) {
 // TEST_F(SignTest, StressTest) {
 // TEST_F(StableSignTest, FailureRate) {
 // TEST(Sign, SymbolicPerturbationCodeCoverage) {


### PR DESCRIPTION
Mirrors the `kMinNoUnderflowError` guard from C++ `s2pred::StableSign` and
ports `TEST(Sign, StableSignUnderflow)`.

Upstream references
- https://github.com/google/s2geometry/blob/fde443b85c018d2991b7459630932add72ef6f76/src/s2/s2predicates.cc#L97-L99
- https://github.com/google/s2geometry/blob/fde443b85c018d2991b7459630932add72ef6f76/src/s2/s2predicates_test.cc#L137-L147