### PR TITLE
Rename dblEpsilon/dblError to machineEpsilon64/unitRoundoff64

### DIFF
--- a/r1/interval.go
+++ b/r1/interval.go
@@ -142,9 +142,9 @@ const (
 	// epsilon is a small number that represents a reasonable level of noise between two
 	// values that can be considered to be equal.
 	epsilon = 1e-15
-	// dblEpsilon is a smaller number for values that require more precision.
+	// machineEpsilon64 is a smaller number for values that require more precision.
 	// This is the C++ DBL_EPSILON equivalent.
-	dblEpsilon = 2.220446049250313e-16
+	machineEpsilon64 = 0x1p-52
 )
 
 // ApproxEqual reports whether the interval can be transformed into the

--- a/r1/interval_test.go
+++ b/r1/interval_test.go
@@ -308,8 +308,8 @@ func TestIntervalString(t *testing.T) {
 func TestApproxEqual(t *testing.T) {
 	// Choose two values lo and hi such that it's okay to shift an endpoint by
 	// kLo (i.e., the resulting interval is equivalent) but not by kHi.
-	const lo = 4 * dblEpsilon // < max_error default
-	const hi = 6 * dblEpsilon // > max_error default
+	const lo = 4 * machineEpsilon64 // < max_error default
+	const hi = 6 * machineEpsilon64 // > max_error default
 
 	tests := []struct {
 		interval Interval

--- a/s1/chordangle.go
+++ b/s1/chordangle.go
@@ -42,8 +42,8 @@ import (
 //	r = 2 * sin((π - x) / 2) = 2 * cos(x / 2)
 //
 // For values of x not close to π the relative error in the squared chord
-// length is at most 4.5 * dblEpsilon (see MaxPointError below).
-// The relative error in "r" is thus at most 2.25 * dblEpsilon ~= 5e-16. To
+// length is at most 4.5 * machineEpsilon64 (see MaxPointError below).
+// The relative error in "r" is thus at most 2.25 * machineEpsilon64 ~= 5e-16. To
 // convert this error into an equivalent angle, we have
 //
 //	|dr / dx| = sin(x / 2)
@@ -81,26 +81,26 @@ import (
 // smaller than this. For example, maximum distance between adjacent
 // representable ChordAngle values is only 13.5 cm rather than 28.5 cm. To
 // see this, observe that the closest representable value to r^2 = 4 is
-// r^2 =  4 * (1 - dblEpsilon / 2). Thus r = 2 * (1 - dblEpsilon / 4) and
+// r^2 =  4 * (1 - machineEpsilon64 / 2). Thus r = 2 * (1 - machineEpsilon64 / 4) and
 // the angle between these two representable values is
 //
 //	x  = 2 * acos(r / 2)
-//	   = 2 * acos(1 - dblEpsilon / 4)
-//	  ~= 2 * asin(sqrt(dblEpsilon / 2)
-//	  ~= sqrt(2 * dblEpsilon)
+//	   = 2 * acos(1 - machineEpsilon64 / 4)
+//	  ~= 2 * asin(sqrt(machineEpsilon64 / 2)
+//	  ~= sqrt(2 * machineEpsilon64)
 //	  ~= 2.1e-8
 //
 // which is 13.5 cm on the Earth's surface.
 //
 // The worst case rounding error occurs when the value halfway between these
 // two representable values is rounded up to 4. This halfway value is
-// r^2 = (4 * (1 - dblEpsilon / 4)), thus r = 2 * (1 - dblEpsilon / 8) and
+// r^2 = (4 * (1 - machineEpsilon64 / 4)), thus r = 2 * (1 - machineEpsilon64 / 8) and
 // the worst case rounding error is
 //
 //	x  = 2 * acos(r / 2)
-//	   = 2 * acos(1 - dblEpsilon / 8)
-//	  ~= 2 * asin(sqrt(dblEpsilon / 4)
-//	  ~= sqrt(dblEpsilon)
+//	   = 2 * acos(1 - machineEpsilon64 / 8)
+//	  ~= 2 * asin(sqrt(machineEpsilon64 / 4)
+//	  ~= sqrt(machineEpsilon64)
 //	  ~= 1.5e-8
 //
 // which is 9.5 cm on the Earth's surface.
@@ -233,17 +233,17 @@ func (c ChordAngle) Predecessor() ChordAngle {
 // bounds guaranteed by s2.Point.Normalize. The error is defined with respect to
 // the true distance after the points are projected to lie exactly on the sphere.
 func (c ChordAngle) MaxPointError() float64 {
-	// There is a relative error of (2.5*dblEpsilon) when computing the squared
-	// distance, plus a relative error of 2 * dblEpsilon, plus an absolute error
-	// of (16 * dblEpsilon**2) because the lengths of the input points may differ
-	// from 1 by up to (2*dblEpsilon) each. (This is the maximum error in Normalize).
-	return 4.5*dblEpsilon*float64(c) + 16*dblEpsilon*dblEpsilon
+	// There is a relative error of (2.5*machineEpsilon64) when computing the squared
+	// distance, plus a relative error of 2 * machineEpsilon64, plus an absolute error
+	// of (16 * machineEpsilon64**2) because the lengths of the input points may differ
+	// from 1 by up to (2*machineEpsilon64) each. (This is the maximum error in Normalize).
+	return 4.5*machineEpsilon64*float64(c) + 16*machineEpsilon64*machineEpsilon64
 }
 
 // MaxAngleError returns the maximum error for a ChordAngle constructed
 // as an Angle distance.
 func (c ChordAngle) MaxAngleError() float64 {
-	return dblEpsilon * float64(c)
+	return machineEpsilon64 * float64(c)
 }
 
 // Add adds the other ChordAngle to this one and returns the resulting value.

--- a/s1/interval.go
+++ b/s1/interval.go
@@ -307,12 +307,12 @@ func (i Interval) AddPoint(p float64) Interval {
 // platform the mantissa precision may be different than others, so we choose to
 // use specific values to be consistent across all.
 // The values come from the C++ implementation.
-var (
+const (
 	// epsilon is a small number that represents a reasonable level of noise between two
 	// values that can be considered to be equal.
 	epsilon = 1e-15
-	// dblEpsilon is a smaller number for values that require more precision.
-	dblEpsilon = 2.220446049e-16
+	// machineEpsilon64 is a smaller number for values that require more precision.
+	machineEpsilon64 = 0x1p-52
 )
 
 // Expanded returns an interval that has been expanded on each side by margin.
@@ -327,7 +327,7 @@ func (i Interval) Expanded(margin float64) Interval {
 		}
 		// Check whether this interval will be full after expansion, allowing
 		// for a rounding error when computing each endpoint.
-		if i.Length()+2*margin+2*dblEpsilon >= 2*math.Pi {
+		if i.Length()+2*margin+2*machineEpsilon64 >= 2*math.Pi {
 			return FullInterval()
 		}
 	} else {
@@ -336,7 +336,7 @@ func (i Interval) Expanded(margin float64) Interval {
 		}
 		// Check whether this interval will be empty after expansion, allowing
 		// for a rounding error when computing each endpoint.
-		if i.Length()+2*margin-2*dblEpsilon <= 0 {
+		if i.Length()+2*margin-2*machineEpsilon64 <= 0 {
 			return EmptyInterval()
 		}
 	}

--- a/s1/interval_test.go
+++ b/s1/interval_test.go
@@ -117,7 +117,7 @@ func TestAlmostFullOrEmpty(t *testing.T) {
 	// Test that rounding errors don't cause intervals that are almost empty or
 	// full to be considered empty or full.  The following value is the greatest
 	// representable value less than Pi.
-	almostPi := math.Pi - 2*dblEpsilon
+	almostPi := math.Pi - 2*machineEpsilon64
 
 	i := Interval{-almostPi, math.Pi}
 	if i.IsFull() {
@@ -464,8 +464,8 @@ func TestIntervalString(t *testing.T) {
 func TestIntervalApproxEqual(t *testing.T) {
 	// Choose two values lo and hi such that it's okay to shift an endpoint by
 	// lo (i.e., the resulting interval is equivalent) but not by hi.
-	lo := 4 * dblEpsilon // < epsilon default
-	hi := 6 * dblEpsilon // > epsilon default
+	lo := 4 * machineEpsilon64 // < epsilon default
+	hi := 6 * machineEpsilon64 // > epsilon default
 
 	tests := []struct {
 		a, b Interval

--- a/s2/builder_snapper.go
+++ b/s2/builder_snapper.go
@@ -216,10 +216,10 @@ func (sf CellIDSnapper) minSnapRadiusForLevel(level int) s1.Angle {
 	// point can move when snapped, taking into account numerical errors.
 	//
 	// The maximum error when converting from a Point to a CellID is
-	// MaxDiagMetric.Deriv * dblEpsilon. The maximum error when converting a
-	// CellID center back to a Point is 1.5 * dblEpsilon. These add up to
-	// just slightly less than 4 * dblEpsilon.
-	return s1.Angle(0.5*MaxDiagMetric.Value(level) + 4*dblEpsilon)
+	// MaxDiagMetric.Deriv * machineEpsilon64. The maximum error when converting a
+	// CellID center back to a Point is 1.5 * machineEpsilon64. These add up to
+	// just slightly less than 4 * machineEpsilon64.
+	return s1.Angle(0.5*MaxDiagMetric.Value(level) + 4*machineEpsilon64)
 }
 
 // levelForMaxSnapRadius reports the minimum Cell level (i.e., largest Cells) such
@@ -235,8 +235,8 @@ func (sf CellIDSnapper) minSnapRadiusForLevel(level int) s1.Angle {
 // TODO(rsned): pop this method out to standalone.
 func (sf CellIDSnapper) levelForMaxSnapRadius(snapRadius s1.Angle) int {
 	// When choosing a level, we need to account for the error bound of
-	// 4 * dblEpsilon that is added by MinSnapRadiusForLevel.
-	return MaxDiagMetric.MinLevel(2 * (snapRadius.Radians() - 4*dblEpsilon))
+	// 4 * machineEpsilon64 that is added by MinSnapRadiusForLevel.
+	return MaxDiagMetric.MinLevel(2 * (snapRadius.Radians() - 4*machineEpsilon64))
 }
 
 // MinVertexSeparation reports the minimum separation between vertices depending
@@ -394,7 +394,7 @@ func (sf IntLatLngSnapper) minSnapRadiusForExponent(exponent int) s1.Angle {
 	// point can move when snapped, taking into account numerical errors.
 	//
 	// The maximum errors in latitude and longitude can be bounded as
-	// follows (as absolute errors in terms of dblEpsilon):
+	// follows (as absolute errors in terms of machineEpsilon64):
 	//
 	//                                      Latitude      Longitude
 	// Convert to LatLng:                      1.000          1.000
@@ -408,15 +408,15 @@ func (sf IntLatLngSnapper) minSnapRadiusForExponent(exponent int) s1.Angle {
 	//
 	// The maximum error when converting the LatLng back to a Point is
 	//
-	//   sqrt(2) * (maximum error in latitude or longitude) + 1.5 * dblEpsilon
+	//   sqrt(2) * (maximum error in latitude or longitude) + 1.5 * machineEpsilon64
 	//
-	// which works out to (9 * sqrt(2) + 1.5) * dblEpsilon radians. Finally
+	// which works out to (9 * sqrt(2) + 1.5) * machineEpsilon64 radians. Finally
 	// we need to consider the effect of rounding to integer coordinates
 	// (much larger than the errors above), which can change the position by
 	// up to (sqrt(2) * 0.5 * sf.to) radians.
 	power := math.Pow10(exponent)
 	return (s1.Degree*s1.Angle((1/math.Sqrt2)/power) +
-		s1.Angle((9*math.Sqrt2+1.5)*dblEpsilon))
+		s1.Angle((9*math.Sqrt2+1.5)*machineEpsilon64))
 }
 
 // exponentForMaxSnapRadius returns the minimum exponent such that vertices will
@@ -427,15 +427,15 @@ func (sf IntLatLngSnapper) minSnapRadiusForExponent(exponent int) s1.Angle {
 // TODO(rsned): Pop this method out so it can be used by other callers.
 func (sf IntLatLngSnapper) exponentForMaxSnapRadius(snapRadius s1.Angle) int {
 	// When choosing an exponent, we need to account for the error bound of
-	// (9 * sqrt(2) + 1.5) * dblEpsilon added by minSnapRadiusForExponent.
-	snapRadius -= (9*math.Sqrt2 + 1.5) * dblEpsilon
+	// (9 * sqrt(2) + 1.5) * machineEpsilon64 added by minSnapRadiusForExponent.
+	snapRadius -= (9*math.Sqrt2 + 1.5) * machineEpsilon64
 	snapRadius = max(snapRadius, 1e-30)
 	exponent := math.Log10((1 / math.Sqrt2) / snapRadius.Degrees())
 
 	// There can be small errors in the calculation above, so to ensure that
 	// this function is the inverse of minSnapRadiusForExponent we subtract a
 	// small error tolerance.
-	return clamp(int(math.Ceil(exponent-2*dblEpsilon)),
+	return clamp(int(math.Ceil(exponent-2*machineEpsilon64)),
 		minIntSnappingExponent, maxIntSnappingExponent)
 }
 

--- a/s2/cap.go
+++ b/s2/cap.go
@@ -306,7 +306,7 @@ func (c Cap) AddCap(other Cap) Cap {
 	// We round up the distance to ensure that the cap is actually contained.
 	// TODO(roberts): Do some error analysis in order to guarantee this.
 	dist := ChordAngleBetweenPoints(c.center, other.center).Add(other.radius)
-	if newRad := dist.Expanded(dblEpsilon * float64(dist)); newRad > c.radius {
+	if newRad := dist.Expanded(machineEpsilon64 * float64(dist)); newRad > c.radius {
 		c.radius = newRad
 	}
 	return c

--- a/s2/cap_test.go
+++ b/s2/cap_test.go
@@ -50,7 +50,7 @@ var (
 	// here.
 	concaveCenter = PointFromLatLng(LatLngFromDegrees(80, 10))
 	concaveRadius = s1.ChordAngleFromAngle(150 * s1.Degree)
-	maxCapError   = concaveRadius.MaxPointError() + concaveRadius.MaxAngleError() + 3*dblEpsilon
+	maxCapError   = concaveRadius.MaxPointError() + concaveRadius.MaxAngleError() + 3*machineEpsilon64
 	concave       = CapFromCenterChordAngle(concaveCenter, concaveRadius)
 	concaveMin    = CapFromCenterChordAngle(concaveCenter, concaveRadius.Expanded(-maxCapError))
 	concaveMax    = CapFromCenterChordAngle(concaveCenter, concaveRadius.Expanded(maxCapError))

--- a/s2/cell.go
+++ b/s2/cell.go
@@ -355,7 +355,7 @@ func (c Cell) longitude(i, j int) float64 {
 }
 
 var (
-	poleMinLat = math.Asin(math.Sqrt(1.0/3)) - 0.5*dblEpsilon
+	poleMinLat = math.Asin(math.Sqrt(1.0/3)) - 0.5*machineEpsilon64
 )
 
 // RectBound returns the bounding rectangle of this cell.
@@ -395,7 +395,7 @@ func (c Cell) RectBound() Rect {
 		// We grow the bounds slightly to make sure that the bounding rectangle
 		// contains LatLngFromPoint(P) for any point P inside the loop L defined by the
 		// four *normalized* vertices.  Note that normalization of a vector can
-		// change its direction by up to 0.5 * dblEpsilon radians, and it is not
+		// change its direction by up to 0.5 * machineEpsilon64 radians, and it is not
 		// enough just to add Normalize calls to the code above because the
 		// latitude/longitude ranges are not necessarily determined by diagonally
 		// opposite vertex pairs after normalization.
@@ -403,18 +403,18 @@ func (c Cell) RectBound() Rect {
 		// We would like to bound the amount by which the latitude/longitude of a
 		// contained point P can exceed the bounds computed above.  In the case of
 		// longitude, the normalization error can change the direction of rounding
-		// leading to a maximum difference in longitude of 2 * dblEpsilon.  In
+		// leading to a maximum difference in longitude of 2 * machineEpsilon64.  In
 		// the case of latitude, the normalization error can shift the latitude by
-		// up to 0.5 * dblEpsilon and the other sources of error can cause the
-		// two latitudes to differ by up to another 1.5 * dblEpsilon, which also
-		// leads to a maximum difference of 2 * dblEpsilon.
-		return Rect{lat, lng}.expanded(LatLng{s1.Angle(2 * dblEpsilon), s1.Angle(2 * dblEpsilon)}).PolarClosure()
+		// up to 0.5 * machineEpsilon64 and the other sources of error can cause the
+		// two latitudes to differ by up to another 1.5 * machineEpsilon64, which also
+		// leads to a maximum difference of 2 * machineEpsilon64.
+		return Rect{lat, lng}.expanded(LatLng{s1.Angle(2 * machineEpsilon64), s1.Angle(2 * machineEpsilon64)}).PolarClosure()
 	}
 
 	// The 4 cells around the equator extend to +/-45 degrees latitude at the
 	// midpoints of their top and bottom edges.  The two cells covering the
 	// poles extend down to +/-35.26 degrees at their vertices.  The maximum
-	// error in this calculation is 0.5 * dblEpsilon.
+	// error in this calculation is 0.5 * machineEpsilon64.
 	var bound Rect
 	switch c.face {
 	case 0:
@@ -437,7 +437,7 @@ func (c Cell) RectBound() Rect {
 	// point, not just the infinite-precision version.) We don't need to expand
 	// longitude because longitude is calculated via a single call to math.Atan2,
 	// which is guaranteed to be semi-monotonic.
-	return bound.expanded(LatLng{s1.Angle(dblEpsilon), s1.Angle(0)})
+	return bound.expanded(LatLng{s1.Angle(machineEpsilon64), s1.Angle(0)})
 }
 
 // CapBound returns the bounding cap of this cell.
@@ -484,9 +484,9 @@ func (c Cell) ContainsPoint(p Point) bool {
 	//
 	// is always true. To do this, we need to account for the error when
 	// converting from (u,v) coordinates to (s,t) coordinates. In the
-	// normal case the total error is at most 1.125 * dblEpsilon.
+	// normal case the total error is at most 1.125 * machineEpsilon64.
 	// See https://github.com/google/s2geometry/issues/463.
-	return c.uv.ExpandedByMargin((1.125 + dblEpsilon) * dblEpsilon).ContainsPoint(uv)
+	return c.uv.ExpandedByMargin((1.125 + machineEpsilon64) * machineEpsilon64).ContainsPoint(uv)
 }
 
 // Encode encodes the Cell.

--- a/s2/cell_test.go
+++ b/s2/cell_test.go
@@ -310,11 +310,11 @@ func testCellChildren(t *testing.T, cell Cell) {
 		// where the cell size at a given level is maximal.
 		maxSizeUV := 0.3964182625366691
 		specialUV := []r2.Point{
-			{X: dblEpsilon, Y: dblEpsilon}, // Face center
-			{X: dblEpsilon, Y: 1},          // Edge midpoint
-			{X: 1, Y: 1},                   // Face corner
-			{X: maxSizeUV, Y: maxSizeUV},   // Largest cell area
-			{X: dblEpsilon, Y: maxSizeUV},  // Longest edge/diagonal
+			{X: machineEpsilon64, Y: machineEpsilon64}, // Face center
+			{X: machineEpsilon64, Y: 1},                // Edge midpoint
+			{X: 1, Y: 1},                               // Face corner
+			{X: maxSizeUV, Y: maxSizeUV},               // Largest cell area
+			{X: machineEpsilon64, Y: maxSizeUV},        // Longest edge/diagonal
 		}
 		forceSubdivide := false
 		for _, uv := range specialUV {

--- a/s2/cellid.go
+++ b/s2/cellid.go
@@ -374,8 +374,8 @@ func CellIDFromString(s string) CellID {
 
 // Point returns the center of the s2 cell on the sphere as a Point.
 // The maximum directional error in Point (compared to the exact
-// mathematical result) is 1.5 * dblEpsilon radians, and the maximum length
-// error is 2 * dblEpsilon (the same as Normalize).
+// mathematical result) is 1.5 * machineEpsilon64 radians, and the maximum length
+// error is 2 * machineEpsilon64 (the same as Normalize).
 func (ci CellID) Point() Point { return Point{ci.rawPoint().Normalize()} }
 
 // LatLng returns the center of the s2 cell on the sphere as a LatLng.

--- a/s2/edge_clipping.go
+++ b/s2/edge_clipping.go
@@ -36,30 +36,30 @@ const (
 	// edgeClipErrorUVCoord is the maximum error in a u- or v-coordinate
 	// compared to the exact result, assuming that the points A and B are in
 	// the rectangle [-1,1]x[1,1] or slightly outside it (by 1e-10 or less).
-	edgeClipErrorUVCoord = 2.25 * dblEpsilon
+	edgeClipErrorUVCoord = 2.25 * machineEpsilon64
 
 	// edgeClipErrorUVDist is the maximum distance from a clipped point to
 	// the corresponding exact result. It is equal to the error in a single
 	// coordinate because at most one coordinate is subject to error.
-	edgeClipErrorUVDist = 2.25 * dblEpsilon
+	edgeClipErrorUVDist = 2.25 * machineEpsilon64
 
 	// faceClipErrorRadians is the maximum angle between a returned vertex
 	// and the nearest point on the exact edge AB. It is equal to the
 	// maximum directional error in PointCross, plus the error when
 	// projecting points onto a cube face.
-	faceClipErrorRadians = 3 * dblEpsilon
+	faceClipErrorRadians = 3 * machineEpsilon64
 
 	// faceClipErrorDist is the same angle expressed as a maximum distance
 	// in (u,v)-space. In other words, a returned vertex is at most this far
 	// from the exact edge AB projected into (u,v)-space.
-	faceClipErrorUVDist = 9 * dblEpsilon
+	faceClipErrorUVDist = 9 * machineEpsilon64
 
 	// faceClipErrorUVCoord is the maximum angle between a returned vertex
 	// and the nearest point on the exact edge AB expressed as the maximum error
 	// in an individual u- or v-coordinate. In other words, for each
 	// returned vertex there is a point on the exact edge AB whose u- and
 	// v-coordinates differ from the vertex by at most this amount.
-	faceClipErrorUVCoord = 9.0 * (1.0 / math.Sqrt2) * dblEpsilon
+	faceClipErrorUVCoord = 9.0 * (1.0 / math.Sqrt2) * machineEpsilon64
 
 	// intersectsRectErrorUVDist is the maximum error when computing if a point
 	// intersects with a given Rect. If some point of AB is inside the
@@ -68,7 +68,7 @@ const (
 	// the result is guaranteed to be false. This bound assumes that rect is
 	// a subset of the rectangle [-1,1]x[-1,1] or extends slightly outside it
 	// (e.g., by 1e-10 or less).
-	intersectsRectErrorUVDist = 3 * math.Sqrt2 * dblEpsilon
+	intersectsRectErrorUVDist = 3 * math.Sqrt2 * machineEpsilon64
 )
 
 // ClipToFace returns the (u,v) coordinates for the portion of the edge AB that
@@ -495,7 +495,7 @@ func clipEdgeBound(a, b r2.Point, clip, bound r2.Rect) (r2.Rect, bool) {
 // This requires a != b.
 //
 // When a <= x <= b or b <= x <= a we can prove the error bound on the resulting
-// value is 2.25*dblEpsilon. The error for extrapolating an x value outside of
+// value is 2.25*machineEpsilon64. The error for extrapolating an x value outside of
 // a and b can be much worse. See the gappa proof at the end of the file.
 func interpolateFloat64(x, a, b, a1, b1 float64) float64 {
 	// If A == B == X all we can return is the single point.

--- a/s2/edge_crosser.go
+++ b/s2/edge_crosser.go
@@ -181,11 +181,11 @@ func (e *EdgeCrosser) crossingSign(d Point, bda Direction) Crossing {
 
 	// The error in RobustCrossProd is insignificant. The maximum error in
 	// the call to CrossProd (i.e., the maximum norm of the error vector) is
-	// (0.5 + 1/sqrt(3)) * dblEpsilon. The maximum error in each call to
-	// DotProd below is dblEpsilon. (There is also a small relative error
+	// (0.5 + 1/sqrt(3)) * machineEpsilon64. The maximum error in each call to
+	// DotProd below is machineEpsilon64. (There is also a small relative error
 	// term that is insignificant because we are comparing the result against a
 	// constant that is very close to zero.)
-	maxError := (1.5 + 1/math.Sqrt(3)) * dblEpsilon
+	maxError := (1.5 + 1/math.Sqrt(3)) * machineEpsilon64
 	if (e.c.Dot(e.aTangent.Vector) > maxError && d.Dot(e.aTangent.Vector) > maxError) || (e.c.Dot(e.bTangent.Vector) > maxError && d.Dot(e.bTangent.Vector) > maxError) {
 		return DoNotCross
 	}

--- a/s2/edge_crossings.go
+++ b/s2/edge_crossings.go
@@ -25,11 +25,11 @@ import (
 const (
 	// intersectionError can be set somewhat arbitrarily, because the algorithm
 	// uses more precision if necessary in order to achieve the specified error.
-	// The only strict requirement is that intersectionError >= dblEpsilon
+	// The only strict requirement is that intersectionError >= machineEpsilon64
 	// radians. However, using a larger error tolerance makes the algorithm more
 	// efficient because it reduces the number of cases where exact arithmetic is
 	// needed.
-	intersectionError = s1.Angle(8 * dblError)
+	intersectionError = s1.Angle(8 * unitRoundoff64)
 
 	// intersectionMergeRadius is used to ensure that intersection points that
 	// are supposed to be coincident are merged back together into a single
@@ -254,15 +254,15 @@ func projection(x, aNorm r3.Vector, aNormLen float64, a0, a1 Point) (proj, bound
 
 	// This calculation bounds the error from all sources: the computation of
 	// the normal, the subtraction of one endpoint, and the dot product itself.
-	// dblError appears because the input points are assumed to be
+	// unitRoundoff64 appears because the input points are assumed to be
 	// normalized in double precision.
 	//
 	// For reference, the bounds that went into this calculation are:
-	// ||N'-N|| <= ((1 + 2 * sqrt(3))||N|| + 32 * sqrt(3) * dblError) * tErr
+	// ||N'-N|| <= ((1 + 2 * sqrt(3))||N|| + 32 * sqrt(3) * unitRoundoff64) * tErr
 	// |(A.B)'-(A.B)| <= (1.5 * (A.B) + 1.5 * ||A|| * ||B||) * tErr
 	// ||(X-Y)'-(X-Y)|| <= ||X-Y|| * tErr
 	tErr := roundingEpsilon(x.X)
-	bound = (((3.5+2*math.Sqrt(3))*aNormLen+32*math.Sqrt(3)*dblError)*dist + 1.5*math.Abs(proj)) * tErr
+	bound = (((3.5+2*math.Sqrt(3))*aNormLen+32*math.Sqrt(3)*unitRoundoff64)*dist + 1.5*math.Abs(proj)) * tErr
 	return proj, bound
 }
 
@@ -378,8 +378,8 @@ func intersectionExact(a0, a1, b0, b1 Point) Point {
 	xP := aNormP.Cross(bNormP)
 
 	// The final Normalize() call is done in double precision, which creates a
-	// directional error of up to 2*dblError. (Precise conversion and Normalize()
-	// each contribute up to dblError of directional error.)
+	// directional error of up to 2*unitRoundoff64. (Precise conversion and Normalize()
+	// each contribute up to unitRoundoff64 of directional error.)
 	x := xP.Vector()
 
 	if x == (r3.Vector{}) {

--- a/s2/edge_crossings_test.go
+++ b/s2/edge_crossings_test.go
@@ -33,7 +33,7 @@ func testIntersectionExact(a0, a1, b0, b1 Point) Point {
 	return x
 }
 
-var distanceAbsError = s1.Angle(3 * dblEpsilon)
+var distanceAbsError = s1.Angle(3 * machineEpsilon64)
 
 func TestEdgeutilIntersectionError(t *testing.T) {
 	// We repeatedly construct two edges that cross near a random point "p", and
@@ -83,12 +83,12 @@ func TestEdgeutilIntersectionError(t *testing.T) {
 			}
 		}
 
-		// Each constructed edge should be at most 1.5 * dblEpsilon away from the
+		// Each constructed edge should be at most 1.5 * machineEpsilon64 away from the
 		// original point P.
-		if got, want := DistanceFromSegment(p, a, b), s1.Angle(1.5*dblEpsilon)+distanceAbsError; got > want {
+		if got, want := DistanceFromSegment(p, a, b), s1.Angle(1.5*machineEpsilon64)+distanceAbsError; got > want {
 			t.Errorf("DistanceFromSegment(%v, %v, %v) = %v, want %v", p, a, b, got, want)
 		}
-		if got, want := DistanceFromSegment(p, c, d), s1.Angle(1.5*dblEpsilon)+distanceAbsError; got > want {
+		if got, want := DistanceFromSegment(p, c, d), s1.Angle(1.5*machineEpsilon64)+distanceAbsError; got > want {
 			t.Errorf("DistanceFromSegment(%v, %v, %v) = %v, want %v", p, c, d, got, want)
 		}
 
@@ -96,13 +96,13 @@ func TestEdgeutilIntersectionError(t *testing.T) {
 		// also close to the original point P. (It might not be very close to P
 		// if the angle between the edges is very small.)
 		expected := testIntersectionExact(a, b, c, d)
-		if got, want := DistanceFromSegment(expected, a, b), s1.Angle(3*dblEpsilon)+distanceAbsError; got > want {
+		if got, want := DistanceFromSegment(expected, a, b), s1.Angle(3*machineEpsilon64)+distanceAbsError; got > want {
 			t.Errorf("DistanceFromSegment(%v, %v, %v) = %v, want %v", expected, a, b, got, want)
 		}
-		if got, want := DistanceFromSegment(expected, c, d), s1.Angle(3*dblEpsilon)+distanceAbsError; got > want {
+		if got, want := DistanceFromSegment(expected, c, d), s1.Angle(3*machineEpsilon64)+distanceAbsError; got > want {
 			t.Errorf("DistanceFromSegment(%v, %v, %v) = %v, want %v", expected, c, d, got, want)
 		}
-		if got, want := expected.Distance(p), s1.Angle(3*dblEpsilon/slope)+intersectionError; got > want {
+		if got, want := expected.Distance(p), s1.Angle(3*machineEpsilon64/slope)+intersectionError; got > want {
 			t.Errorf("%v.Distance(%v) = %v, want %v", expected, p, got, want)
 		}
 

--- a/s2/edge_distances.go
+++ b/s2/edge_distances.go
@@ -206,7 +206,7 @@ func minUpdateInteriorDistanceMaxError(dist s1.ChordAngle) float64 {
 	a := math.Sqrt(b * (2 - b))
 	return ((2.5+2*sqrt3+8.5*a)*a +
 		(2+2*sqrt3/3+6.5*(1-b))*b +
-		(23+16/sqrt3)*dblEpsilon) * dblEpsilon
+		(23+16/sqrt3)*machineEpsilon64) * machineEpsilon64
 }
 
 // updateMinDistance computes the distance from a point X to a line segment AB,
@@ -260,21 +260,21 @@ func interiorDist(x, a, b Point, minDist s1.ChordAngle, alwaysUpdate bool) (s1.C
 	//
 	// There are two sources of error in the expression above (*).  The first is
 	// that points are not normalized exactly; they are only guaranteed to be
-	// within 2 * dblEpsilon of unit length.  Under the assumption that the two
+	// within 2 * machineEpsilon64 of unit length.  Under the assumption that the two
 	// sides of (*) are nearly equal, the total error due to normalization errors
 	// can be shown to be at most
 	//
-	//        2 * dblEpsilon * (XA^2 + XB^2 + AB^2) + 8 * dblEpsilon ^ 2 .
+	//        2 * machineEpsilon64 * (XA^2 + XB^2 + AB^2) + 8 * machineEpsilon64 ^ 2 .
 	//
 	// The other source of error is rounding of results in the calculation of (*).
-	// Each of XA^2, XB^2, AB^2 has a maximum relative error of 2.5 * dblEpsilon,
-	// plus an additional relative error of 0.5 * dblEpsilon in the final
-	// subtraction which we further bound as 0.25 * dblEpsilon * (XA^2 + XB^2 +
+	// Each of XA^2, XB^2, AB^2 has a maximum relative error of 2.5 * machineEpsilon64,
+	// plus an additional relative error of 0.5 * machineEpsilon64 in the final
+	// subtraction which we further bound as 0.25 * machineEpsilon64 * (XA^2 + XB^2 +
 	// AB^2) for convenience.  This yields a final error bound of
 	//
-	//        4.75 * dblEpsilon * (XA^2 + XB^2 + AB^2) + 8 * dblEpsilon ^ 2 .
+	//        4.75 * machineEpsilon64 * (XA^2 + XB^2 + AB^2) + 8 * machineEpsilon64 ^ 2 .
 	ab2 := a.Sub(b.Vector).Norm2()
-	maxError := (4.75*dblEpsilon*(xa2+xb2+ab2) + 8*dblEpsilon*dblEpsilon)
+	maxError := (4.75*machineEpsilon64*(xa2+xb2+ab2) + 8*machineEpsilon64*machineEpsilon64)
 	if math.Abs(xa2-xb2) >= ab2+maxError {
 		return minDist, false
 	}

--- a/s2/latlng.go
+++ b/s2/latlng.go
@@ -80,7 +80,7 @@ func longitude(p Point) s1.Angle {
 }
 
 // PointFromLatLng returns a Point for the given LatLng.
-// The maximum error in the result is 1.5 * dblEpsilon. (This does not
+// The maximum error in the result is 1.5 * machineEpsilon64. (This does not
 // include the error of converting degrees, E5, E6, or E7 into radians.)
 func PointFromLatLng(ll LatLng) Point {
 	phi := ll.Lat.Radians()

--- a/s2/loop.go
+++ b/s2/loop.go
@@ -823,7 +823,7 @@ func (l *Loop) TurningAngle() float64 {
 		n--
 	}
 
-	const maxCurvature = 2*math.Pi - 4*dblEpsilon
+	const maxCurvature = 2*math.Pi - 4*machineEpsilon64
 
 	return math.Max(-maxCurvature, math.Min(maxCurvature, float64(dir)*float64(sum+compensation)))
 }
@@ -832,13 +832,13 @@ func (l *Loop) TurningAngle() float64 {
 // constant; it depends on the loop.
 func (l *Loop) turningAngleMaxError() float64 {
 	// The maximum error can be bounded as follows:
-	//   3.00 * dblEpsilon    for RobustCrossProd(b, a)
-	//   3.00 * dblEpsilon    for RobustCrossProd(c, b)
-	//   3.25 * dblEpsilon    for Angle()
-	//   2.00 * dblEpsilon    for each addition in the Kahan summation
+	//   3.00 * machineEpsilon64    for RobustCrossProd(b, a)
+	//   3.00 * machineEpsilon64    for RobustCrossProd(c, b)
+	//   3.25 * machineEpsilon64    for Angle()
+	//   2.00 * machineEpsilon64    for each addition in the Kahan summation
 	//   ------------------
-	//  11.25 * dblEpsilon
-	maxErrorPerVertex := 11.25 * dblEpsilon
+	//  11.25 * machineEpsilon64
+	maxErrorPerVertex := 11.25 * machineEpsilon64
 	return maxErrorPerVertex * float64(len(l.vertices))
 }
 

--- a/s2/loop_test.go
+++ b/s2/loop_test.go
@@ -321,7 +321,7 @@ func TestLoopRectBound(t *testing.T) {
 	arctic80Inv.Invert()
 	// The highest latitude of each edge is attained at its midpoint.
 	mid := Point{arctic80Inv.vertices[0].Vector.Add(arctic80Inv.vertices[1].Vector).Mul(.5)}
-	if got, want := arctic80Inv.RectBound().Lat.Hi, float64(LatLngFromPoint(mid).Lat); !float64Near(got, want, 10*dblEpsilon) {
+	if got, want := arctic80Inv.RectBound().Lat.Hi, float64(LatLngFromPoint(mid).Lat); !float64Near(got, want, 10*machineEpsilon64) {
 		t.Errorf("arctic 80 inverse loop's RectBound should have a latutude hi of %v, got %v", got, want)
 	}
 }

--- a/s2/paddedcell.go
+++ b/s2/paddedcell.go
@@ -218,7 +218,7 @@ func (p *PaddedCell) ShrinkToFit(rect r2.Rect) CellID {
 
 	// Increase the padding to compensate for the error in uvToST.
 	// (The constant below is a provable upper bound on the additional error.)
-	padded := rect.ExpandedByMargin(p.padding + 1.5*dblEpsilon)
+	padded := rect.ExpandedByMargin(p.padding + 1.5*machineEpsilon64)
 	iMin, jMin := p.iLo, p.jLo // Min i- or j- coordinate spanned by padded
 	var iXor, jXor int         // XOR of the min and max i- or j-coordinates
 

--- a/s2/point.go
+++ b/s2/point.go
@@ -330,7 +330,7 @@ func (p Point) IsNormalizable() bool {
 	// magnitudes of ab.CrossProd(cd) and ab.DotProd(cd) is at least 2**-968,
 	// which ensures that any denormalized terms in these two calculations do
 	// not affect the accuracy of the result (since all denormalized numbers are
-	// smaller than 2**-1022, which is less than dblError * 2**-968).
+	// smaller than 2**-1022, which is less than unitRoundoff64 * 2**-968).
 	//
 	// The fastest way to ensure this is to test whether the largest component of
 	// the result has a magnitude of at least 2**-242.

--- a/s2/predicates.go
+++ b/s2/predicates.go
@@ -35,11 +35,11 @@ const (
 	// If any other machine architectures need to be supported, these next
 	// values will need to be updated.
 
-	// dblEpsilon is a smaller number for values that require more precision.
+	// machineEpsilon64 is a smaller number for values that require more precision.
 	// This is the C++ DBL_EPSILON equivalent.
-	dblEpsilon = 2.220446049250313e-16
-	// dblError is the C++ value for S2 rounding_epsilon().
-	dblError = 1.110223024625156e-16
+	machineEpsilon64 = 0x1p-52
+	// unitRoundoff64 is the C++ value for S2 rounding_epsilon().
+	unitRoundoff64 = machineEpsilon64 / 2
 	// smallestNormalFloat64 is the C++ DBL_MIN equivalent.
 	smallestNormalFloat64 = 0x1p-1022
 
@@ -64,7 +64,7 @@ const (
 	// relative error (which does not affect the sign of the result), we get
 	//
 	//  fl((AxB).C) = (AxB).C + d where |d| <= (3 + 2/sqrt(3)) * e
-	maxDeterminantError = 1.8274 * dblEpsilon
+	maxDeterminantError = 1.8274 * machineEpsilon64
 
 	// detErrorMultiplier is the factor to scale the magnitudes by when checking
 	// for the sign of set of points with certainty. Using a similar technique to
@@ -74,7 +74,7 @@ const (
 	//
 	// If the determinant magnitude is larger than this value then we know
 	// its sign with certainty.
-	detErrorMultiplier = 3.2321 * dblEpsilon
+	detErrorMultiplier = 3.2321 * machineEpsilon64
 )
 
 // epsilonForDigits reports the epsilon for the given number of digits of mantissa.
@@ -522,7 +522,7 @@ func CompareDistances(x, a, b Point) int {
 // maximum error amount in the result. This requires X and Y be normalized.
 func cosDistance(x, y Point) (cos, err float64) {
 	cos = x.Dot(y.Vector)
-	return cos, 9.5*dblError*math.Abs(cos) + 1.5*dblError
+	return cos, 9.5*unitRoundoff64*math.Abs(cos) + 1.5*unitRoundoff64
 }
 
 // sin2Distance returns sin**2(XY), where XY is the angle between X and Y,
@@ -530,13 +530,13 @@ func cosDistance(x, y Point) (cos, err float64) {
 func sin2Distance(x, y Point) (sin2, err float64) {
 	// The (x-y).Cross(x+y) trick eliminates almost all of error due to x
 	// and y being not quite unit length. This method is extremely accurate
-	// for small distances; the *relative* error in the result is O(dblError) for
-	// distances as small as dblError.
+	// for small distances; the *relative* error in the result is O(unitRoundoff64) for
+	// distances as small as unitRoundoff64.
 	n := x.Sub(y.Vector).Cross(x.Add(y.Vector))
 	sin2 = 0.25 * n.Norm2()
-	err = ((21+4*sqrt3)*dblError*sin2 +
-		32*sqrt3*dblError*dblError*math.Sqrt(sin2) +
-		768*dblError*dblError*dblError*dblError)
+	err = ((21+4*sqrt3)*unitRoundoff64*sin2 +
+		32*sqrt3*unitRoundoff64*unitRoundoff64*math.Sqrt(sin2) +
+		768*unitRoundoff64*unitRoundoff64*unitRoundoff64*unitRoundoff64)
 	return sin2, err
 }
 
@@ -666,7 +666,7 @@ func CompareDistance(x, y Point, r s1.ChordAngle) int {
 func triageCompareCosDistance(x, y Point, r2 float64) int {
 	cosXY, cosXYError := cosDistance(x, y)
 	cosR := 1.0 - 0.5*r2
-	cosRError := 2.0 * dblError * cosR
+	cosRError := 2.0 * unitRoundoff64 * cosR
 	diff := cosXY - cosR
 	err := cosXYError + cosRError
 	if diff > err {
@@ -684,7 +684,7 @@ func triageCompareSin2Distance(x, y Point, r2 float64) int {
 	// Only valid for distance limits < 90 degrees.
 	sin2XY, sin2XYError := sin2Distance(x, y)
 	sin2R := r2 * (1.0 - 0.25*r2)
-	sin2RError := 3.0 * dblError * sin2R
+	sin2RError := 3.0 * unitRoundoff64 * sin2R
 	diff := sin2XY - sin2R
 	err := sin2XYError + sin2RError
 	if diff > err {
@@ -753,7 +753,7 @@ func triageSignDotProd(a, b Point) int {
 	// Reference:
 	//   Error Estimation Of Floating-Point Summation And Dot Product, Rump
 	//   2011
-	const maxError = 3.046875 * dblEpsilon
+	const maxError = 3.046875 * machineEpsilon64
 
 	na := a.Dot(b.Vector)
 	if math.Abs(na) <= maxError {
@@ -885,7 +885,7 @@ func triageIntersectionOrdering(a, b, c, d, m, n Point) int {
 	// only interested in the sign of this operation, as long as the relative
 	// error is < 1 we can never get a sign flip, which would make this exact for
 	// our purposes.
-	const maxError = 32 * dblEpsilon
+	const maxError = 32 * machineEpsilon64
 
 	mdota := m.Dot(a.Vector)
 	mdotb := m.Dot(b.Vector)

--- a/s2/predicates_test.go
+++ b/s2/predicates_test.go
@@ -73,7 +73,7 @@ func TestRoundingEpsilon(t *testing.T) {
 		t.Errorf("roundingEpsilon(float32) = %g, want %g", got, want)
 	}
 
-	if got, want := roundingEpsilon(f64), dblEpsilon*0.5; got != want {
+	if got, want := roundingEpsilon(f64), machineEpsilon64*0.5; got != want {
 		t.Errorf("roundingEpsilon(float64) = %g, want %g", got, want)
 	}
 }
@@ -744,23 +744,23 @@ func TestPredicatesCompareDistanceCoverage(t *testing.T) {
 		},
 		{
 			x:        PointFromCoords(1, 1e-40, 0),
-			y:        PointFromCoords(1+dblEpsilon, 1e-40, 0),
-			r:        s1.ChordAngleFromAngle(0.9 * dblEpsilon * 1e-40),
+			y:        PointFromCoords(1+machineEpsilon64, 1e-40, 0),
+			r:        s1.ChordAngleFromAngle(0.9 * machineEpsilon64 * 1e-40),
 			distFunc: triageCompareSin2Distance,
 			wantSign: 1,
 			wantPrec: exactPrecision,
 		},
 		{
 			x:        PointFromCoords(1, 1e-40, 0),
-			y:        PointFromCoords(1+dblEpsilon, 1e-40, 0),
-			r:        s1.ChordAngleFromAngle(1.1 * dblEpsilon * 1e-40),
+			y:        PointFromCoords(1+machineEpsilon64, 1e-40, 0),
+			r:        s1.ChordAngleFromAngle(1.1 * machineEpsilon64 * 1e-40),
 			distFunc: triageCompareSin2Distance,
 			wantSign: -1,
 			wantPrec: exactPrecision,
 		},
 		{
 			x:        PointFromCoords(1, 0, 0),
-			y:        PointFromCoords(1+dblEpsilon, 0, 0),
+			y:        PointFromCoords(1+machineEpsilon64, 0, 0),
 			r:        s1.ChordAngle(0),
 			distFunc: triageCompareSin2Distance,
 			wantSign: 0,
@@ -785,7 +785,7 @@ func TestPredicatesCompareDistanceCoverage(t *testing.T) {
 		},
 		{
 			x:        PointFromCoords(1, 1, 0),
-			y:        PointFromCoords(1, -1-2*dblEpsilon, 0),
+			y:        PointFromCoords(1, -1-2*machineEpsilon64, 0),
 			r:        s1.RightChordAngle,
 			distFunc: triageCompareCosDistance,
 			wantSign: 1,
@@ -793,7 +793,7 @@ func TestPredicatesCompareDistanceCoverage(t *testing.T) {
 		},
 		{
 			x:        PointFromCoords(1, 1, 0),
-			y:        PointFromCoords(1, -1-dblEpsilon, 0),
+			y:        PointFromCoords(1, -1-machineEpsilon64, 0),
 			r:        s1.RightChordAngle,
 			distFunc: triageCompareCosDistance,
 			wantSign: 1,
@@ -1030,7 +1030,7 @@ func TestPredicatesSignDotProd(t *testing.T) {
 		{
 			//  NearlyOrthogonalPositive
 			a:         PointFromCoords(1, 0, 0),
-			b:         PointFromCoords(dblEpsilon, 1, 0),
+			b:         PointFromCoords(machineEpsilon64, 1, 0),
 			want:      1,
 			precision: "EXACT",
 		},
@@ -1044,7 +1044,7 @@ func TestPredicatesSignDotProd(t *testing.T) {
 		{
 			// NearlyOrthogonalNegative
 			a:         PointFromCoords(1, 0, 0),
-			b:         PointFromCoords(-dblEpsilon, 1, 0),
+			b:         PointFromCoords(-machineEpsilon64, 1, 0),
 			want:      -1,
 			precision: "EXACT",
 		},

--- a/s2/rect_bounder.go
+++ b/s2/rect_bounder.go
@@ -52,16 +52,16 @@ func NewRectBounder() *RectBounder {
 // result does not include either pole. It is only used for testing purposes
 func (r *RectBounder) maxErrorForTests() LatLng {
 	// The maximum error in the latitude calculation is
-	//    3.84 * dblEpsilon   for the PointCross calculation
-	//    0.96 * dblEpsilon   for the Latitude calculation
-	//    5    * dblEpsilon   added by AddPoint/RectBound to compensate for error
+	//    3.84 * machineEpsilon64   for the PointCross calculation
+	//    0.96 * machineEpsilon64   for the Latitude calculation
+	//    5    * machineEpsilon64   added by AddPoint/RectBound to compensate for error
 	//    -----------------
-	//    9.80 * dblEpsilon   maximum error in result
+	//    9.80 * machineEpsilon64   maximum error in result
 	//
-	// The maximum error in the longitude calculation is dblEpsilon. RectBound
+	// The maximum error in the longitude calculation is machineEpsilon64. RectBound
 	// does not do any expansion because this isn't necessary in order to
 	// bound the *rounded* longitudes of contained points.
-	return LatLng{10 * dblEpsilon * s1.Radian, 1 * dblEpsilon * s1.Radian}
+	return LatLng{10 * machineEpsilon64 * s1.Radian, 1 * machineEpsilon64 * s1.Radian}
 }
 
 // AddPoint adds the given point to the chain. The Point must be unit length.
@@ -86,24 +86,24 @@ func (r *RectBounder) AddPoint(b Point) {
 	// by choosing a maximum allowable error, and if the error is greater than
 	// this we fall back to a different technique. Since it turns out that
 	// the other sources of error in converting the normal to a maximum
-	// latitude add up to at most 1.16 * dblEpsilon, and it is desirable to
-	// have the total error be a multiple of dblEpsilon, we have chosen to
-	// limit the maximum error in the normal to be 3.84 * dblEpsilon.
+	// latitude add up to at most 1.16 * machineEpsilon64, and it is desirable to
+	// have the total error be a multiple of machineEpsilon64, we have chosen to
+	// limit the maximum error in the normal to be 3.84 * machineEpsilon64.
 	// It is possible to show that the error is less than this when
 	//
-	// n.Norm() >= 8 * sqrt(3) / (3.84 - 0.5 - sqrt(3)) * dblEpsilon
-	//          = 1.91346e-15 (about 8.618 * dblEpsilon)
+	// n.Norm() >= 8 * sqrt(3) / (3.84 - 0.5 - sqrt(3)) * machineEpsilon64
+	//          = 1.91346e-15 (about 8.618 * machineEpsilon64)
 	nNorm := n.Norm()
 	if nNorm < 1.91346e-15 {
 		// A and B are either nearly identical or nearly antipodal (to within
-		// 4.309 * dblEpsilon, or about 6 nanometers on the earth's surface).
+		// 4.309 * machineEpsilon64, or about 6 nanometers on the earth's surface).
 		if r.a.Dot(b.Vector) < 0 {
 			// The two points are nearly antipodal. The easiest solution is to
 			// assume that the edge between A and B could go in any direction
 			// around the sphere.
 			r.bound = FullRect()
 		} else {
-			// The two points are nearly identical (to within 4.309 * dblEpsilon).
+			// The two points are nearly identical (to within 4.309 * machineEpsilon64).
 			// In this case we can just use the bounding rectangle of the points,
 			// since after the expansion done by GetBound this Rect is
 			// guaranteed to include the (lat,lng) values of all points along AB.
@@ -116,7 +116,7 @@ func (r *RectBounder) AddPoint(b Point) {
 
 	// Compute the longitude range spanned by AB.
 	lngAB := s1.EmptyInterval().AddPoint(r.aLL.Lng.Radians()).AddPoint(bLL.Lng.Radians())
-	if lngAB.Length() >= math.Pi-2*dblEpsilon {
+	if lngAB.Length() >= math.Pi-2*machineEpsilon64 {
 		// The points lie on nearly opposite lines of longitude to within the
 		// maximum error of the calculation. The easiest solution is to assume
 		// that AB could go on either side of the pole.
@@ -140,7 +140,7 @@ func (r *RectBounder) AddPoint(b Point) {
 	// the error in these calculations. It is possible to show that the
 	// total error is bounded by
 	//
-	// (1 + sqrt(3)) * dblEpsilon * nNorm + 8 * sqrt(3) * (dblEpsilon**2)
+	// (1 + sqrt(3)) * machineEpsilon64 * nNorm + 8 * sqrt(3) * (machineEpsilon64**2)
 	//   = 6.06638e-16 * nNorm + 6.83174e-31
 
 	mError := 6.06638e-16*nNorm + 6.83174e-31
@@ -154,18 +154,18 @@ func (r *RectBounder) AddPoint(b Point) {
 		// Our goal is compute a bound that contains the computed latitudes of
 		// all S2Points P that pass the point-in-polygon containment test.
 		// There are three sources of error we need to consider:
-		// - the directional error in N (at most 3.84 * dblEpsilon)
+		// - the directional error in N (at most 3.84 * machineEpsilon64)
 		// - converting N to a maximum latitude
 		// - computing the latitude of the test point P
-		// The latter two sources of error are at most 0.955 * dblEpsilon
+		// The latter two sources of error are at most 0.955 * machineEpsilon64
 		// individually, but it is possible to show by a more complex analysis
-		// that together they can add up to at most 1.16 * dblEpsilon, for a
-		// total error of 5 * dblEpsilon.
+		// that together they can add up to at most 1.16 * machineEpsilon64, for a
+		// total error of 5 * machineEpsilon64.
 		//
-		// We add 3 * dblEpsilon to the bound here, and GetBound() will pad
-		// the bound by another 2 * dblEpsilon.
+		// We add 3 * machineEpsilon64 to the bound here, and GetBound() will pad
+		// the bound by another 2 * machineEpsilon64.
 		maxLat := math.Min(
-			math.Atan2(math.Sqrt(n.X*n.X+n.Y*n.Y), math.Abs(n.Z))+3*dblEpsilon,
+			math.Atan2(math.Sqrt(n.X*n.X+n.Y*n.Y), math.Abs(n.Z))+3*machineEpsilon64,
 			math.Pi/2)
 
 		// In order to get tight bounds when the two points are close together,
@@ -178,7 +178,7 @@ func (r *RectBounder) AddPoint(b Point) {
 		// distance (in latitude) from A or B to the min or max latitude
 		// attained along the edge AB.
 		latBudget := 2 * math.Asin(0.5*(r.a.Sub(b.Vector)).Norm()*math.Sin(maxLat))
-		maxDelta := 0.5*(latBudget-latAB.Length()) + dblEpsilon
+		maxDelta := 0.5*(latBudget-latAB.Length()) + machineEpsilon64
 
 		// Test whether AB passes through the point of maximum latitude or
 		// minimum latitude. If the dot product(s) are small enough then the
@@ -200,7 +200,7 @@ func (r *RectBounder) AddPoint(b Point) {
 // above, i.e. if the edge chain defines a Loop, then the bound contains
 // the LatLng coordinates of all Points contained by the loop.
 func (r *RectBounder) RectBound() Rect {
-	return r.bound.expanded(LatLng{s1.Angle(2 * dblEpsilon), 0}).PolarClosure()
+	return r.bound.expanded(LatLng{s1.Angle(2 * machineEpsilon64), 0}).PolarClosure()
 }
 
 // ExpandForSubregions expands a bounding Rect so that it is guaranteed to
@@ -224,7 +224,7 @@ func ExpandForSubregions(bound Rect) Rect {
 	}
 
 	// First we need to check whether the bound B contains any nearly-antipodal
-	// points (to within 4.309 * dblEpsilon). If so then we need to return
+	// points (to within 4.309 * machineEpsilon64). If so then we need to return
 	// FullRect, since the subregion might have an edge between two
 	// such points, and AddPoint returns Full for such edges. Note that
 	// this can happen even if B is not Full for example, consider a loop
@@ -234,12 +234,12 @@ func ExpandForSubregions(bound Rect) Rect {
 	// It is easy to check whether B contains any antipodal points, but checking
 	// for nearly-antipodal points is trickier. Essentially we consider the
 	// original bound B and its reflection through the origin B', and then test
-	// whether the minimum distance between B and B' is less than 4.309 * dblEpsilon.
+	// whether the minimum distance between B and B' is less than 4.309 * machineEpsilon64.
 
 	// lngGap is a lower bound on the longitudinal distance between B and its
-	// reflection B'. (2.5 * dblEpsilon is the maximum combined error of the
+	// reflection B'. (2.5 * machineEpsilon64 is the maximum combined error of the
 	// endpoint longitude calculations and the Length call.)
-	lngGap := math.Max(0, math.Pi-bound.Lng.Length()-2.5*dblEpsilon)
+	lngGap := math.Max(0, math.Pi-bound.Lng.Length()-2.5*machineEpsilon64)
 
 	// minAbsLat is the minimum distance from B to the equator (if zero or
 	// negative, then B straddles the equator).
@@ -258,7 +258,7 @@ func ExpandForSubregions(bound Rect) Rect {
 		// distance is lngGap. We could compute the distance exactly using the
 		// Haversine formula, but then we would need to bound the errors in that
 		// calculation. Since we only need accuracy when the distance is very
-		// small (close to 4.309 * dblEpsilon), we substitute the Euclidean
+		// small (close to 4.309 * machineEpsilon64), we substitute the Euclidean
 		// distance instead. This gives us a right triangle XYZ with two edges of
 		// length x = 2*minAbsLat and y ~= lngGap. The desired distance is the
 		// length of the third edge z, and we have
@@ -267,7 +267,7 @@ func ExpandForSubregions(bound Rect) Rect {
 		//
 		// Therefore the region may contain nearly antipodal points only if
 		//
-		//  2*minAbsLat + lngGap  <  sqrt(2) * 4.309 * dblEpsilon
+		//  2*minAbsLat + lngGap  <  sqrt(2) * 4.309 * machineEpsilon64
 		//                        ~= 1.354e-15
 		//
 		// Note that because the given bound B is conservative, minAbsLat and
@@ -288,10 +288,10 @@ func ExpandForSubregions(bound Rect) Rect {
 		// Unlike the case above, latGapSouth and latGapNorth are not lower bounds
 		// (because of the extra addition operation, and because math.Pi/2 is not
 		// exactly equal to Pi/2); they can exceed their true values by up to
-		// 0.75 * dblEpsilon. Putting this all together, the region may contain
+		// 0.75 * machineEpsilon64. Putting this all together, the region may contain
 		// nearly antipodal points only if
 		//
-		//   latGapSouth + latGapNorth  <  (sqrt(2) * 4.309 + 1.5) * dblEpsilon
+		//   latGapSouth + latGapNorth  <  (sqrt(2) * 4.309 + 1.5) * machineEpsilon64
 		//                              ~= 1.687e-15
 		if latGapSouth+latGapNorth < 1.687e-15 {
 			return FullRect()
@@ -319,30 +319,30 @@ func ExpandForSubregions(bound Rect) Rect {
 		// for 0 <= t <= Pi/2, that we only need an accurate approximation when
 		// at least one of "maxLatGap" or lngGap is extremely small (in which
 		// case sin(t) ~= t), and recalling that "maxLatGap" has an error of up
-		// to 0.75 * dblEpsilon, we want to test whether
+		// to 0.75 * machineEpsilon64, we want to test whether
 		//
-		//   maxLatGap * lngGap  <  (4.309 + 0.75) * (Pi/2) * dblEpsilon
+		//   maxLatGap * lngGap  <  (4.309 + 0.75) * (Pi/2) * machineEpsilon64
 		//                       ~= 1.765e-15
 		if math.Max(latGapSouth, latGapNorth)*lngGap < 1.765e-15 {
 			return FullRect()
 		}
 	}
 	// Next we need to check whether the subregion might contain any edges that
-	// span (math.Pi - 2 * dblEpsilon) radians or more in longitude, since AddPoint
+	// span (math.Pi - 2 * machineEpsilon64) radians or more in longitude, since AddPoint
 	// sets the longitude bound to Full in that case. This corresponds to
 	// testing whether (lngGap <= 0) in lngExpansion below.
 
-	// Otherwise, the maximum latitude error in AddPoint is 4.8 * dblEpsilon.
+	// Otherwise, the maximum latitude error in AddPoint is 4.8 * machineEpsilon64.
 	// In the worst case, the errors when computing the latitude bound for a
 	// subregion could go in the opposite direction as the errors when computing
 	// the bound for the original region, so we need to double this value.
 	// (More analysis shows that it's okay to round down to a multiple of
-	// dblEpsilon.)
+	// machineEpsilon64.)
 	//
 	// For longitude, we rely on the fact that atan2 is correctly rounded and
 	// therefore no additional bounds expansion is necessary.
 
-	latExpansion := 9 * dblEpsilon
+	latExpansion := 9 * machineEpsilon64
 	lngExpansion := 0.0
 	if lngGap <= 0 {
 		lngExpansion = math.Pi

--- a/s2/rect_bounder_test.go
+++ b/s2/rect_bounder_test.go
@@ -109,7 +109,7 @@ func TestRectBounderMaxLatitudeEdgeInterior(t *testing.T) {
 
 func TestRectBounderMaxLatitudeRandom(t *testing.T) {
 	// Check that the maximum latitude of edges is computed accurately to within
-	// 3 * dblEpsilon (the expected maximum error). We concentrate on maximum
+	// 3 * machineEpsilon64 (the expected maximum error). We concentrate on maximum
 	// latitudes near the equator and north pole since these are the extremes.
 
 	for range 100 {
@@ -117,7 +117,7 @@ func TestRectBounderMaxLatitudeRandom(t *testing.T) {
 		// slightly above the equator, V points at the equator, and W is slightly
 		// offset from the north pole.
 		u := randomPoint()
-		u.Z = dblEpsilon * 1e-6 * math.Pow(1e12, randomFloat64())
+		u.Z = machineEpsilon64 * 1e-6 * math.Pow(1e12, randomFloat64())
 
 		u = Point{u.Normalize()}
 		v := Point{PointFromCoords(0, 0, 1).PointCross(u).Normalize()}

--- a/s2/s2_test.go
+++ b/s2/s2_test.go
@@ -269,8 +269,8 @@ func r1IntervalsApproxEqual(a, b r1.Interval, epsilon float64) bool {
 }
 
 var (
-	rectErrorLat = 10 * dblEpsilon
-	rectErrorLng = dblEpsilon
+	rectErrorLat = 10 * machineEpsilon64
+	rectErrorLng = machineEpsilon64
 )
 
 // r2PointsApproxEqual reports whether the two points are within the given epsilon.
@@ -361,7 +361,7 @@ func perturbATowardsB(a, b Point, r ...*rand.Rand) Point {
 		// Return a point that is exactly proportional to A and that still
 		// satisfies IsUnitLength().
 		for {
-			b := Point{a.Mul(2 - a.Norm() + 5*(randomFloat64(r...)-0.5)*dblEpsilon)}
+			b := Point{a.Mul(2 - a.Norm() + 5*(randomFloat64(r...)-0.5)*machineEpsilon64)}
 			if !b.ApproxEqual(a) && b.IsUnit() {
 				return b
 			}
@@ -371,9 +371,9 @@ func perturbATowardsB(a, b Point, r ...*rand.Rand) Point {
 		// Return a point such that the distance squared to A will underflow.
 		return InterpolateAtDistance(1e-300, a, b)
 	}
-	// Otherwise return a point whose distance from A is near dblEpsilon such
+	// Otherwise return a point whose distance from A is near machineEpsilon64 such
 	// that the log of the pdf is uniformly distributed.
-	distance := dblEpsilon * 1e-5 * math.Pow(1e6, randomFloat64(r...))
+	distance := machineEpsilon64 * 1e-5 * math.Pow(1e6, randomFloat64(r...))
 	return InterpolateAtDistance(s1.Angle(distance), a, b)
 }
 
@@ -395,7 +395,7 @@ func perturbedCornerOrMidpoint(p, q Point, r ...*rand.Rand) Point {
 		// For coordinates near 1 (say > 0.5), this perturbation
 		// yields values that are only a few representable values
 		// away from the initial value.
-		a = a.Add(randomPoint(r...).Mul(4 * dblEpsilon))
+		a = a.Add(randomPoint(r...).Mul(4 * machineEpsilon64))
 	} else {
 		// A perturbation whose magnitude is in the range [1e-25, 1e-10].
 		// TODO(rsned): Change this from Mul(1e-10 * math.Pow...) to

--- a/s2/stuv.go
+++ b/s2/stuv.go
@@ -150,9 +150,9 @@ const (
 	// The maximum absolute error in U/V coordinates when converting from XYZ.
 	//
 	// The XYZ -> UV conversion is a single division per coordinate, which is
-	// promised to be at most 0.5*dblEpsilon absolute error for values with
+	// promised to be at most 0.5*machineEpsilon64 absolute error for values with
 	// magnitude less than two.
-	maxXYZtoUVError = 0.5 * dblEpsilon
+	maxXYZtoUVError = 0.5 * machineEpsilon64
 
 	// maxSiTi is the maximum value of an si- or ti-coordinate.
 	// It is one shift more than MaxSize. The range of valid (si,ti)


### PR DESCRIPTION
These seem more idiomatic since Go doesn't have "double".