### PR TITLE
Update "double precision" references in comments

### DIFF
--- a/r3/precisevector_test.go
+++ b/r3/precisevector_test.go
@@ -500,7 +500,7 @@ func TestPreciseVectorIsZero(t *testing.T) {
 		},
 		{
 			// 1e20+1-1e20 should equal 1.  Testing the case where the
-			// numbers are outside the range a traditional double would
+			// numbers are outside the range a traditional float64 would
 			// be able to handle correctly.
 			have: x.Add(y).Add(x.Mul(precFloat(-1))),
 			want: false,

--- a/s1/angle.go
+++ b/s1/angle.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 )
 
-// Angle represents a 1D angle. The internal representation is a double precision
+// Angle represents a 1D angle. The internal representation is a float64
 // value in radians, so conversion to and from radians is exact.
 // Conversions between E5, E6, E7, and Degrees are not always
 // exact. For example, Degrees(3.1) is different from E6(3100000) or E7(31000000).

--- a/s2/edge_crosser_test.go
+++ b/s2/edge_crosser_test.go
@@ -118,7 +118,7 @@ func TestEdgeCrosserCrossings(t *testing.T) {
 			edgeOrVertex: false,
 		},
 		{
-			// This example cannot be handled using regular double-precision
+			// This example cannot be handled using regular float64
 			// arithmetic due to floating-point underflow.
 			msg:          "two edges that barely cross each other near the end of both edges",
 			a:            Point{r3.Vector{X: 0, Y: 0, Z: 1}},

--- a/s2/edge_crossings.go
+++ b/s2/edge_crossings.go
@@ -363,7 +363,7 @@ func intersectionStableSorted(a0, a1, b0, b1 Point) (Point, bool) {
 
 // intersectionExact returns the intersection point of (a0, a1) and (b0, b1)
 // using precise arithmetic. Note that the result is not exact because it is
-// rounded down to double precision at the end. Also, the intersection point
+// rounded down to float64 at the end. Also, the intersection point
 // is not guaranteed to have the correct sign (i.e., the return value may need
 // to be negated).
 func intersectionExact(a0, a1, b0, b1 Point) Point {

--- a/s2/loop_test.go
+++ b/s2/loop_test.go
@@ -64,7 +64,7 @@ var (
 
 	// A nearly-degenerate CCW chevron near the equator with very long sides
 	// (about 80 degrees).  Its area is less than 1e-640, which is too small
-	// to represent in double precision.
+	// to represent in float64.
 	skinnyChevron = LoopFromPoints(parsePoints("0:0, -1e-320:80, 0:1e-320, 1e-320:80"))
 
 	// A diamond-shaped loop around the point 0:180.

--- a/s2/point.go
+++ b/s2/point.go
@@ -349,7 +349,7 @@ func (p Point) EnsureNormalizable() Point {
 	}
 	if !p.IsNormalizable() {
 		// We can't just scale by a fixed factor because the smallest representable
-		// double is 2**-1074, so if we multiplied by 2**(1074 - 242) then the
+		// float64 is 2**-1074, so if we multiplied by 2**(1074 - 242) then the
 		// result might be so large that we couldn't square it without overflow.
 		//
 		// Note that we must scale by a power of two to avoid rounding errors.

--- a/s2/pointcompression.go
+++ b/s2/pointcompression.go
@@ -131,7 +131,7 @@ func encodeFirstPointFixedLength(e *encoder, pi, qi uint32, level int, piCoder, 
 //
 // In addition, provides a lossless method to compress a sequence of points even
 // if some points are not the center of level-k cells. These points are stored
-// exactly, using 3 double precision values, after the above encoded string,
+// exactly, using 3 float64 values, after the above encoded string,
 // together with their index in the sequence (this leads to some redundancy - it
 // is expected that only a small fraction of the points are not cell centers).
 //

--- a/s2/predicates_test.go
+++ b/s2/predicates_test.go
@@ -1206,7 +1206,7 @@ func TestPredicatesCircleEdgeIntersectionOrdering(t *testing.T) {
 				i, test.a, test.b, test.c, test.d, test.m, test.n, got, test.want)
 		}
 
-		// We triage in double precision and then fall back to exact for 0.
+		// We triage in float64 and then fall back to exact for 0.
 		actualPrec := "EXACT"
 		if triageIntersectionOrdering(test.a, test.b, test.c, test.d, test.m, test.n) != 0 {
 			actualPrec = "DOUBLE"

--- a/s2/rect_bounder_test.go
+++ b/s2/rect_bounder_test.go
@@ -168,7 +168,7 @@ func TestRectBounderExpandForSubregions(t *testing.T) {
 		{1e-100, 22e-16, 1e-14, math.Pi, false},
 		// Cases where the bound spans at most 90 degrees in longitude, and almost
 		// 180 degrees in latitude.  Note that DBL_EPSILON is about 2.22e-16, which
-		// implies that the double-precision value just below Pi/2 can be written as
+		// implies that the float64 value just below Pi/2 can be written as
 		// (math.Pi/2 - 2e-16).
 		{-math.Pi / 2, -1e-15, math.Pi/2 - 7e-16, 0, true},
 		{-math.Pi / 2, -1e-15, math.Pi/2 - 30e-16, 0, false},


### PR DESCRIPTION
Update comments to use "float64" instead of C++-style "double" or "double precision".