### PR TITLE
s2: decode compressed (v2) polylines

### DIFF
--- a/s2/encode.go
+++ b/s2/encode.go
@@ -29,6 +29,11 @@ const (
 	// encodingCompressedVersion is the current version of the
 	// compressed format.
 	encodingCompressedVersion = int8(4)
+
+	// encodingPolylineCompressedVersion is the current version of the compressed
+	// polyline format. It matches upstream C++:
+	// s2polyline.cc: kCurrentCompressedEncodingVersionNumber = 2.
+	encodingPolylineCompressedVersion = int8(2)
 )
 
 // encoder handles the specifics of encoding for S2 types.

--- a/s2/encode.go
+++ b/s2/encode.go
@@ -26,13 +26,12 @@ const (
 	// format that is compatible with C++ and other S2 libraries.
 	encodingVersion = int8(1)
 
-	// encodingCompressedVersion is the current version of the
-	// compressed format.
-	encodingCompressedVersion = int8(4)
+	// encodingPolygonCompressedVersion is the current version of the
+	// compressed polygon format.
+	encodingPolygonCompressedVersion = int8(4)
 
-	// encodingPolylineCompressedVersion is the current version of the compressed
-	// polyline format. It matches upstream C++:
-	// s2polyline.cc: kCurrentCompressedEncodingVersionNumber = 2.
+	// encodingPolylineCompressedVersion is the current version of the
+	// compressed polyline format.
 	encodingPolylineCompressedVersion = int8(2)
 )
 

--- a/s2/polygon.go
+++ b/s2/polygon.go
@@ -1107,7 +1107,7 @@ func (p *Polygon) encodeLossless(e *encoder) {
 }
 
 func (p *Polygon) encodeCompressed(e *encoder, snapLevel int, vertices []xyzFaceSiTi) {
-	e.writeUint8(uint8(encodingCompressedVersion))
+	e.writeUint8(uint8(encodingPolygonCompressedVersion))
 	e.writeUint8(uint8(snapLevel))
 	e.writeUvarint(uint64(len(p.loops)))
 
@@ -1136,7 +1136,7 @@ func (p *Polygon) Decode(r io.Reader) error {
 	switch version {
 	case encodingVersion:
 		dec = p.decode
-	case encodingCompressedVersion:
+	case encodingPolygonCompressedVersion:
 		dec = p.decodeCompressed
 	default:
 		return fmt.Errorf("unsupported version %d", version)

--- a/s2/polyline.go
+++ b/s2/polyline.go
@@ -370,10 +370,6 @@ func (p Polyline) encode(e *encoder) {
 }
 
 func (p Polyline) encodeCompressed(e *encoder, snapLevel int) {
-	if snapLevel < 0 || snapLevel > MaxLevel {
-		e.err = fmt.Errorf("snapLevel %d out of range [0, %d]", snapLevel, MaxLevel)
-		return
-	}
 	if len(p) > maxEncodedVertices {
 		e.err = fmt.Errorf("too many vertices (%d; max is %d)", len(p), maxEncodedVertices)
 		return
@@ -450,6 +446,9 @@ func (p *Polyline) decodeCompressed(d *decoder) {
 	}
 
 	*p = make(Polyline, nvertices)
+	if nvertices == 0 {
+		return
+	}
 	decodePointsCompressed(d, snapLevel, *p)
 }
 

--- a/s2/polyline.go
+++ b/s2/polyline.go
@@ -369,22 +369,51 @@ func (p Polyline) encode(e *encoder) {
 	}
 }
 
-// Decode decodes the polyline.
+func (p Polyline) encodeCompressed(e *encoder, snapLevel int) {
+	if snapLevel < 0 || snapLevel > MaxLevel {
+		e.err = fmt.Errorf("snapLevel %d out of range [0, %d]", snapLevel, MaxLevel)
+		return
+	}
+	if len(p) > maxEncodedVertices {
+		e.err = fmt.Errorf("too many vertices (%d; max is %d)", len(p), maxEncodedVertices)
+		return
+	}
+
+	e.writeUint8(uint8(encodingPolylineCompressedVersion))
+	e.writeUint8(uint8(snapLevel))
+	e.writeUvarint(uint64(len(p)))
+	if e.err != nil {
+		return
+	}
+
+	vs := make([]xyzFaceSiTi, len(p))
+	for i, v := range p {
+		vs[i].xyz = v
+		vs[i].face, vs[i].si, vs[i].ti, vs[i].level = xyzToFaceSiTi(v)
+	}
+	encodePointsCompressed(e, vs, snapLevel)
+}
+
+// Decode decodes the polyline from either the lossless (version 1) or
+// compressed (version 2) wire format.
 func (p *Polyline) Decode(r io.Reader) error {
-	d := decoder{r: asByteReader(r)}
-	p.decode(d)
+	d := &decoder{r: asByteReader(r)}
+	version := int8(d.readUint8())
+	if d.err != nil {
+		return d.err
+	}
+	switch version {
+	case encodingVersion:
+		p.decodeLossless(d)
+	case encodingPolylineCompressedVersion:
+		p.decodeCompressed(d)
+	default:
+		return fmt.Errorf("unsupported version %d", version)
+	}
 	return d.err
 }
 
-func (p *Polyline) decode(d decoder) {
-	version := d.readInt8()
-	if d.err != nil {
-		return
-	}
-	if int(version) != int(encodingVersion) {
-		d.err = fmt.Errorf("can't decode version %d; my version: %d", version, encodingVersion)
-		return
-	}
+func (p *Polyline) decodeLossless(d *decoder) {
 	nvertices := d.readUint32()
 	if d.err != nil {
 		return
@@ -399,6 +428,29 @@ func (p *Polyline) decode(d decoder) {
 		(*p)[i].Y = d.readFloat64()
 		(*p)[i].Z = d.readFloat64()
 	}
+}
+
+func (p *Polyline) decodeCompressed(d *decoder) {
+	snapLevel := int(d.readUint8())
+	if d.err != nil {
+		return
+	}
+	if snapLevel > MaxLevel {
+		d.err = fmt.Errorf("snap level %d > MaxLevel %d", snapLevel, MaxLevel)
+		return
+	}
+
+	nvertices := d.readUvarint()
+	if d.err != nil {
+		return
+	}
+	if nvertices > maxEncodedVertices {
+		d.err = fmt.Errorf("too many vertices (%d; max is %d)", nvertices, maxEncodedVertices)
+		return
+	}
+
+	*p = make(Polyline, nvertices)
+	decodePointsCompressed(d, snapLevel, *p)
 }
 
 // Project returns a point on the polyline that is closest to the given point,
@@ -585,4 +637,4 @@ func (p *Polyline) Uninterpolate(point Point, nextVertex int) float64 {
 // InitToSnapped
 // InitToSimplified
 // SnapLevel
-// encode/decode compressed
+// EncodeMostCompact

--- a/s2/polyline_test.go
+++ b/s2/polyline_test.go
@@ -686,6 +686,35 @@ func TestPolylineDecodeCompressedBadData(t *testing.T) {
 	}
 }
 
+func TestPolylineDecodeCompressedEmpty(t *testing.T) {
+	// Bytes for an empty polyline: version 2, snap level 0, nvertices 0.
+	// C++ S2Polyline::DecodeCompressed returns early and does not read further.
+	// Go should do the same and not fail with EOF trying to read numOffCenter.
+	encoded := []byte{byte(encodingPolylineCompressedVersion), 0, 0}
+
+	var p Polyline
+	if err := p.Decode(bytes.NewReader(encoded)); err != nil {
+		t.Fatalf("Decode(empty polyline) = %v, want nil", err)
+	}
+	if len(p) != 0 {
+		t.Fatalf("len(p) = %d, want 0", len(p))
+	}
+}
+
+func TestPolylineDecodeCompressedMaxCellLevel(t *testing.T) {
+	// Mirrors C++ TEST(S2Polyline, DecodeCompressedMaxCellLevel).
+	encoded := []byte{
+		byte(encodingPolylineCompressedVersion),
+		byte(MaxLevel),
+		0, 0, 0, 0,
+	}
+
+	var p Polyline
+	if err := p.Decode(bytes.NewReader(encoded)); err != nil {
+		t.Fatalf("Decode(max cell level) = %v, want nil", err)
+	}
+}
+
 func TestPolylineDecodeCompressedCellLevelTooHigh(t *testing.T) {
 	// Mirrors C++ TEST(S2Polyline, DecodeCompressedCellLevelTooHigh).
 	encoded := []byte{byte(encodingPolylineCompressedVersion), byte(MaxLevel + 1), 0x00}
@@ -696,7 +725,6 @@ func TestPolylineDecodeCompressedCellLevelTooHigh(t *testing.T) {
 }
 
 func TestPolylineDecodeRejectsUnknownVersion(t *testing.T) {
-	// Regression-guard the by-value decoder bug in the old implementation.
 	encoded := []byte{0x05, 0x00, 0x00}
 	var p Polyline
 	err := p.Decode(bytes.NewReader(encoded))

--- a/s2/polyline_test.go
+++ b/s2/polyline_test.go
@@ -15,8 +15,11 @@
 package s2
 
 import (
+	"bytes"
+	"encoding/hex"
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/golang/geo/r3"
@@ -621,6 +624,136 @@ func TestPolylineUninterpolate(t *testing.T) {
 	// Check that the return value is clamped to 1.0.
 	if got, want := line.Uninterpolate(PointFromCoords(0, 1, 0), len(line)), 1.0; !float64Eq(got, want) {
 		t.Errorf("line.Uninterpolate(%v, %d) = %v, want %v", PointFromCoords(0, 1, 0), len(line), got, want)
+	}
+}
+
+func encodeCompressedPolyline(t *testing.T, p Polyline, snapLevel int) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	e := &encoder{w: &buf}
+	p.encodeCompressed(e, snapLevel)
+	if e.err != nil {
+		t.Fatalf("encodeCompressed(level=%d): %v", snapLevel, e.err)
+	}
+	return buf.Bytes()
+}
+
+func TestPolylineDecodeCompressedRoundTrip(t *testing.T) {
+	orig := Polyline{
+		PointFromLatLng(LatLngFromDegrees(10, 10)),
+		PointFromLatLng(LatLngFromDegrees(10.1, 10.1)),
+		PointFromLatLng(LatLngFromDegrees(10.2, 10.2)),
+		PointFromLatLng(LatLngFromDegrees(10.3, 10.3)),
+	}
+
+	for _, snapLevel := range []int{0, 15, MaxLevel} {
+		snapped := make(Polyline, len(orig))
+		for i, pt := range orig {
+			snapped[i] = cellIDFromPoint(pt).Parent(snapLevel).Point()
+		}
+
+		// Mix in a deliberately unsnapped vertex to exercise the off-center path,
+		// which serializes (x, y, z) float64s verbatim.
+		mixed := append(Polyline(nil), snapped...)
+		mixed[len(mixed)/2] = orig[len(orig)/2]
+
+		for _, p := range []*Polyline{&snapped, &mixed} {
+			var got Polyline
+			if err := got.Decode(bytes.NewReader(encodeCompressedPolyline(t, *p, snapLevel))); err != nil {
+				t.Fatalf("Decode(level=%d): %v", snapLevel, err)
+			}
+
+			if len(got) != len(*p) {
+				t.Fatalf("len(Decode(encodeCompressed)) = %d, want %d", len(got), len(*p))
+			}
+			for i := range got {
+				if !got[i].ApproxEqual((*p)[i]) {
+					t.Fatalf("vertex %d mismatch at snapLevel %d: got %v want %v", i, snapLevel, got[i], (*p)[i])
+				}
+			}
+		}
+	}
+}
+
+func TestPolylineDecodeCompressedBadData(t *testing.T) {
+	// Use a version-2 header so this exercises the compressed decode path rather
+	// than failing immediately as an unknown version.
+	bad := []byte{byte(encodingPolylineCompressedVersion), 0, 1, 0xff}
+	var p Polyline
+	if err := p.Decode(bytes.NewReader(bad)); err == nil {
+		t.Fatalf("Decode(bad data) got nil error, want non-nil")
+	}
+}
+
+func TestPolylineDecodeCompressedCellLevelTooHigh(t *testing.T) {
+	// Mirrors C++ TEST(S2Polyline, DecodeCompressedCellLevelTooHigh).
+	encoded := []byte{byte(encodingPolylineCompressedVersion), byte(MaxLevel + 1), 0x00}
+	var p Polyline
+	if err := p.Decode(bytes.NewReader(encoded)); err == nil {
+		t.Fatalf("Decode(level too high) got nil error, want non-nil")
+	}
+}
+
+func TestPolylineDecodeRejectsUnknownVersion(t *testing.T) {
+	// Regression-guard the by-value decoder bug in the old implementation.
+	encoded := []byte{0x05, 0x00, 0x00}
+	var p Polyline
+	err := p.Decode(bytes.NewReader(encoded))
+	if err == nil {
+		t.Fatalf("Decode(unknown version) got nil error, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported version") {
+		t.Fatalf("Decode(unknown version) error = %q, want substring %q", err, "unsupported version")
+	}
+}
+
+// TestPolylineEncodeCompressedGolden locks the wire bytes emitted by the
+// internal compressed polyline encoder helper so accidental format changes are
+// caught in CI. It is NOT a cross-compatibility proof with C++; it only guards
+// against unintended Go-side regressions.
+//
+// TODO(#232): replace with a C++-produced fixture when one is available.
+func TestPolylineEncodeCompressedGolden(t *testing.T) {
+	p := PolylineFromLatLngs([]LatLng{
+		LatLngFromDegrees(0, 0),
+		LatLngFromDegrees(0, 10),
+		LatLngFromDegrees(10, 20),
+		LatLngFromDegrees(20, 30),
+	})
+
+	tests := []struct {
+		level int
+		want  string
+	}{
+		{
+			level: 0,
+			want:  "020004180000000301181c818c8b83ef3f89730b7e1a3ac63f00000000000000000262b46c3a039ded3fe2dc829f868ed53f89730b7e1a3ac63f031b995e6fa10aea3f1b2d5242f611de3ff50b8a74a8e3d53f",
+		},
+		{
+			level: MaxLevel,
+			want:  "021e0418000000000000000cc4aa94a0d080c12ac1fd83b09ba3d18002ed90d9f2b6e6030400000000000000f03f0000000000000000000000000000000001181c818c8b83ef3f89730b7e1a3ac63f00000000000000000262b46c3a039ded3fe2dc829f868ed53f89730b7e1a3ac63f031b995e6fa10aea3f1b2d5242f611de3ff50b8a74a8e3d53f",
+		},
+	}
+	for _, tt := range tests {
+		raw := encodeCompressedPolyline(t, *p, tt.level)
+		if got := hex.EncodeToString(raw); got != tt.want {
+			t.Errorf("EncodeCompressed(level=%d) hex = %q, want %q", tt.level, got, tt.want)
+		}
+
+		// Round-trip the golden bytes through Decode to make sure the same
+		// payload is still accepted.
+		var decoded Polyline
+		golden, err := hex.DecodeString(tt.want)
+		if err != nil {
+			t.Fatalf("hex.DecodeString: %v", err)
+		}
+		if err := decoded.Decode(bytes.NewReader(golden)); err != nil {
+			t.Fatalf("Decode(golden level=%d): %v", tt.level, err)
+		}
+		if !decoded.ApproxEqual(p) {
+			t.Errorf("Decode(golden level=%d) got %v, want %v", tt.level, decoded, *p)
+		}
 	}
 }
 

--- a/s2/polyline_test.go
+++ b/s2/polyline_test.go
@@ -740,8 +740,6 @@ func TestPolylineDecodeRejectsUnknownVersion(t *testing.T) {
 // internal compressed polyline encoder helper so accidental format changes are
 // caught in CI. It is NOT a cross-compatibility proof with C++; it only guards
 // against unintended Go-side regressions.
-//
-// TODO(#232): replace with a C++-produced fixture when one is available.
 func TestPolylineEncodeCompressedGolden(t *testing.T) {
 	p := PolylineFromLatLngs([]LatLng{
 		LatLngFromDegrees(0, 0),


### PR DESCRIPTION
**Fixes #232**

**Background**
Go `Polyline.Decode` currently accepts only the lossless version-1 wire format, but upstream C++ S2 also emits compressed polylines using version 2.

**Implementation**
This change adds a polyline-specific `encodingPolylineCompressedVersion = 2` constant and extends `Polyline.Decode` to dispatch on both version 1 and version 2. The version-2 path reuses the existing `decodePointsCompressed` primitive already used by Loop/Polygon. The polygon-specific compressed version-4 path is unchanged.

**Bug Fixes & Testing**
This also fixes the existing by-value decoder helper bug in polyline decode error propagation, and adds regression tests for compressed round-trip decode, bad compressed input, snap-level bounds, unknown-version rejection, and a Go-side wire-format golden.