### PR TITLE
predicates_test: Fix BenchmarkSign measuring empty loop

### DIFF
--- a/s2/predicates_test.go
+++ b/s2/predicates_test.go
@@ -1226,12 +1226,19 @@ func TestPredicatesCircleEdgeIntersectionOrdering(t *testing.T) {
 
 // ---------------------------------- Benchmarks ---------------------------
 
+// signNoInline prevents the Sign() call from being DCE'd.
+//
+//go:noinline
+func signNoInline(p1, p2, p3 Point) bool {
+	return Sign(p1, p2, p3)
+}
+
 func BenchmarkSign(b *testing.B) {
 	p1 := Point{r3.Vector{X: -3, Y: -1, Z: 4}}
 	p2 := Point{r3.Vector{X: 2, Y: -1, Z: -3}}
 	p3 := Point{r3.Vector{X: 1, Y: -2, Z: 0}}
 	for i := 0; i < b.N; i++ {
-		Sign(p1, p2, p3)
+		signNoInline(p1, p2, p3)
 	}
 }
 

--- a/s2/predicates_test.go
+++ b/s2/predicates_test.go
@@ -1226,23 +1226,47 @@ func TestPredicatesCircleEdgeIntersectionOrdering(t *testing.T) {
 
 // ---------------------------------- Benchmarks ---------------------------
 
+func benchmarkPoints(n int) []Point {
+	pts := make([]Point, n)
+	for i := range pts {
+		pts[i] = randomPoint()
+	}
+	return pts
+}
+
 func BenchmarkSign(b *testing.B) {
-	p1 := Point{r3.Vector{X: -3, Y: -1, Z: 4}}
-	p2 := Point{r3.Vector{X: 2, Y: -1, Z: -3}}
-	p3 := Point{r3.Vector{X: 1, Y: -2, Z: 0}}
-	for i := 0; i < b.N; i++ {
-		Sign(p1, p2, p3)
+	pts := benchmarkPoints(256)
+	b.ResetTimer()
+	// The next triple of points to test depends on the result of the previous
+	// call so the calls cannot be optimized away.
+	j := 0
+	for range b.N {
+		if Sign(pts[j], pts[j+1], pts[j+2]) {
+			j++
+		}
+		j++
+		if j+2 >= len(pts) {
+			j = 0
+		}
 	}
 }
 
 // BenchmarkRobustSignSimple runs the benchmark for points that satisfy the first
 // checks in RobustSign to compare the performance to that of Sign().
 func BenchmarkRobustSignSimple(b *testing.B) {
-	p1 := Point{r3.Vector{X: -3, Y: -1, Z: 4}}
-	p2 := Point{r3.Vector{X: 2, Y: -1, Z: -3}}
-	p3 := Point{r3.Vector{X: 1, Y: -2, Z: 0}}
-	for i := 0; i < b.N; i++ {
-		RobustSign(p1, p2, p3)
+	pts := benchmarkPoints(256)
+	b.ResetTimer()
+	// The next triple of points to test depends on the result of the previous
+	// call so the calls cannot be optimized away.
+	j := 0
+	for range b.N {
+		if RobustSign(pts[j], pts[j+1], pts[j+2]) == Clockwise {
+			j++
+		}
+		j++
+		if j+2 >= len(pts) {
+			j = 0
+		}
 	}
 }
 


### PR DESCRIPTION
Comparing assemblies from objdump:
```
> diff -u /tmp/before.s /tmp/after.s
--- /tmp/before.s	2026-04-30 00:43:25.516557064 -0700
+++ /tmp/after.s	2026-04-30 00:43:35.893749762 -0700
@@ -1,7 +1,33 @@
+  493b6610 CMPQ SP, 0x10(R14)
+  7671 JBE 0x70ff97
+  55 PUSHQ BP
+  4889e5 MOVQ SP, BP
+  4883ec50 SUBQ $0x50, SP
+  4889442460 MOVQ AX, 0x60(SP)
   31c9 XORL CX, CX
-  eb03 JMP 0x70fec7
+  eb51 JMP 0x70ff88
+  48894c2448 MOVQ CX, 0x48(SP)
+  f20f10051cad0f00 MOVSD_XMM $f64.c008000000000000(SB), X0
+  f20f100d6ca00f00 MOVSD_XMM 0xfa06c(IP), X1
+  f20f10155ca00f00 MOVSD_XMM 0xfa05c(IP), X2
+  f20f101dd4a00f00 MOVSD_XMM 0xfa0d4(IP), X3
+  0f10e1 MOVUPS X1, X4
+  0f10e8 MOVUPS X0, X5
+  f20f10355ea00f00 MOVSD_XMM 0xfa05e(IP), X6
+  f20f103dceac0f00 MOVSD_XMM $f64.c000000000000000(SB), X7
+  450f57c0 XORPS X8, X8
+  e845ffffff CALL github.com/golang/geo/s2.signNoInline(SB)
+  488b4c2448 MOVQ 0x48(SP), CX
   48ffc1 INCQ CX
+  488b442460 MOVQ 0x60(SP), AX
   48398810020000 CMPQ 0x210(AX), CX
-  7ff4 JG 0x70fec4
+  7fa6 JG 0x70ff37
+  4883c450 ADDQ $0x50, SP
+  5d POPQ BP
   c3 RET
+  4889442408 MOVQ AX, 0x8(SP)
+  0f1f4000 NOPL 0(AX)
+  e81b14d8ff CALL runtime.morestack_noctxt.abi0(SB)
+  488b442408 MOVQ 0x8(SP), AX
+  e971ffffff JMP github.com/golang/geo/s2.BenchmarkSign(SB)
```

Benchmarks:
```
> benchstat /tmp/before.txt /tmp/after.txt
goos: linux
goarch: amd64
pkg: github.com/golang/geo/s2
cpu: AMD Ryzen 7 PRO 8840HS w/ Radeon 780M Graphics
        │ /tmp/before.txt │             /tmp/after.txt             │
        │     sec/op      │    sec/op      vs base                 │
Sign-16      0.2083n ± 2%   1.5070n ± 13%  +623.48% (p=0.000 n=10)
```
