### PR TITLE
Rename unidiomatic ret variables to descriptive names

### DIFF
--- a/s2/interleave_test.go
+++ b/s2/interleave_test.go
@@ -25,12 +25,12 @@ func TestInterleaveUint32(t *testing.T) {
 }
 
 func referenceBitInterleave(x, y uint32) uint64 {
-	var ret uint64
+	var v uint64
 	for i := range uint(32) {
-		ret |= uint64((x>>i)&1) << (i * 2)
-		ret |= uint64((y>>i)&1) << (i*2 + 1)
+		v |= uint64((x>>i)&1) << (i * 2)
+		v |= uint64((y>>i)&1) << (i*2 + 1)
 	}
-	return ret
+	return v
 }
 
 func TestInterleaveUint32AgainstReference(t *testing.T) {

--- a/s2/loop.go
+++ b/s2/loop.go
@@ -1324,12 +1324,12 @@ const (
 )
 
 func (l *Loop) xyzFaceSiTiVertices() []xyzFaceSiTi {
-	ret := make([]xyzFaceSiTi, len(l.vertices))
+	verts := make([]xyzFaceSiTi, len(l.vertices))
 	for i, v := range l.vertices {
-		ret[i].xyz = v
-		ret[i].face, ret[i].si, ret[i].ti, ret[i].level = xyzToFaceSiTi(v)
+		verts[i].xyz = v
+		verts[i].face, verts[i].si, verts[i].ti, verts[i].level = xyzToFaceSiTi(v)
 	}
-	return ret
+	return verts
 }
 
 func (l *Loop) encodeCompressed(e *encoder, snapLevel int, vertices []xyzFaceSiTi) {

--- a/s2/pointcompression.go
+++ b/s2/pointcompression.go
@@ -154,14 +154,14 @@ type faceRun struct {
 
 func decodeFaceRun(d *decoder) faceRun {
 	faceAndCount := d.readUvarint()
-	ret := faceRun{
+	fr := faceRun{
 		face:  int(faceAndCount % NumFaces),
 		count: int(faceAndCount / NumFaces),
 	}
-	if ret.count <= 0 && d.err == nil {
+	if fr.count <= 0 && d.err == nil {
 		d.err = errors.New("non-positive count for face run")
 	}
-	return ret
+	return fr
 }
 
 func decodeFaces(numVertices int, d *decoder) []faceRun {

--- a/s2/polygon.go
+++ b/s2/polygon.go
@@ -430,7 +430,7 @@ func (p *Polygon) initEdgesAndIndex() {
 
 // FullPolygon returns a special "full" polygon.
 func FullPolygon() *Polygon {
-	ret := &Polygon{
+	p := &Polygon{
 		loops: []*Loop{
 			FullLoop(),
 		},
@@ -438,8 +438,8 @@ func FullPolygon() *Polygon {
 		bound:          FullRect(),
 		subregionBound: FullRect(),
 	}
-	ret.initEdgesAndIndex()
-	return ret
+	p.initEdgesAndIndex()
+	return p
 }
 
 // Validate checks whether this is a valid polygon,

--- a/s2/regionunion.go
+++ b/s2/regionunion.go
@@ -34,11 +34,11 @@ func (ru RegionUnion) CapBound() Cap { return ru.RectBound().CapBound() }
 
 // RectBound returns a bounding latitude-longitude rectangle for this RegionUnion.
 func (ru RegionUnion) RectBound() Rect {
-	ret := EmptyRect()
+	rect := EmptyRect()
 	for _, reg := range ru {
-		ret = ret.Union(reg.RectBound())
+		rect = rect.Union(reg.RectBound())
 	}
-	return ret
+	return rect
 }
 
 // ContainsCell reports whether the given Cell is contained by this RegionUnion.


### PR DESCRIPTION
Replace generic ret variable names with idiomatic Go names that reflect the type or purpose of the value: rect, v, verts, fr, p.