### PR TITLE
cell_test: Use math.Log1p instead of math.Log(1+x) in TestCellAreas

### DIFF
--- a/s2/cell_test.go
+++ b/s2/cell_test.go
@@ -335,9 +335,9 @@ func testCellChildren(t *testing.T, cell Cell) {
 
 func TestCellAreas(t *testing.T) {
 	// relative error bounds for each type of area computation
-	var exactError = math.Log(1 + 1e-6)
-	var approxError = math.Log(1.03)
-	var avgError = math.Log(1 + 1e-15)
+	var exactError = math.Log1p(1e-6)
+	var approxError = math.Log1p(0.03)
+	var avgError = math.Log1p(1e-15)
 
 	// Test 1. Check the area of a top level cell.
 	const level1Cell = CellID(0x1000000000000000)


### PR DESCRIPTION
Log1p computes ln(1+x) without the intermediate float64 addition, which loses precision when x is small (especially the 1e-15 case where 1+1e-15 rounds before the log). These are tolerance bounds so the precision loss didn't cause test failures, but Log1p is both more precise and better expresses the intent.