### PR TITLE
add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+To report a security issue, please use [https://g.co/vulnz](https://g.co/vulnz).
+We use g.co/vulnz for our intake, and do coordination and disclosure here on
+GitHub (including using GitHub Security Advisory). The Google Security Team will
+respond within 5 working days of your report on g.co/vulnz.


### PR DESCRIPTION
We'll use g.co/vulnz for our intake, and do coordination and disclosure here on GitHub (including using GitHub Security Advisory).

Fixes #290 